### PR TITLE
Feat: 시간표 조회 api

### DIFF
--- a/src/main/java/com/kurierfree/server/domain/auth/constant/JwtGrantType.java
+++ b/src/main/java/com/kurierfree/server/domain/auth/constant/JwtGrantType.java
@@ -1,0 +1,16 @@
+package com.kurierfree.server.domain.auth.constant;
+
+import lombok.Getter;
+
+@Getter
+public enum JwtGrantType {
+    GRANT_TYPE_USER("USER"),
+    GRANT_TYPE_ADMIN("ADMIN");
+
+    private final String value;
+
+    JwtGrantType(String value) {
+        this.value = value;
+    }
+
+}

--- a/src/main/java/com/kurierfree/server/domain/auth/constant/JwtTokenExpireTime.java
+++ b/src/main/java/com/kurierfree/server/domain/auth/constant/JwtTokenExpireTime.java
@@ -1,0 +1,15 @@
+package com.kurierfree.server.domain.auth.constant;
+
+import lombok.Getter;
+
+@Getter
+public enum JwtTokenExpireTime {
+    ACCESS_TOKEN_EXPIRE_TIME(86400000),
+    REFRESH_TOKEN_EXPIRE_TIME(86400000);
+
+    private final long expireTime;
+
+    JwtTokenExpireTime(long expireTime) {
+        this.expireTime = expireTime;
+    }
+}

--- a/src/main/java/com/kurierfree/server/domain/auth/enhancer/JwtAuthenticationFilter.java
+++ b/src/main/java/com/kurierfree/server/domain/auth/enhancer/JwtAuthenticationFilter.java
@@ -12,11 +12,14 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.GenericFilterBean;
 
+import static com.kurierfree.server.domain.auth.constant.JwtGrantType.GRANT_TYPE_ADMIN;
+import static com.kurierfree.server.domain.auth.constant.JwtGrantType.GRANT_TYPE_USER;
+
 
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends GenericFilterBean {
     private final JwtProvider jwtTokenProvider;
-    private static final String GRANT_TYPE = "user";
+
 
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
@@ -37,7 +40,9 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
     // Request Header에서 토큰 정보 추출
     private String resolveToken(HttpServletRequest request) {
         String bearerToken = request.getHeader("Authorization");
-        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(GRANT_TYPE)) {
+        if (StringUtils.hasText(bearerToken) &&
+                ((bearerToken.startsWith(GRANT_TYPE_USER.getValue())) || (bearerToken.startsWith(GRANT_TYPE_ADMIN.getValue())))
+        ) {
             return bearerToken.substring(7);
         }
         return null;

--- a/src/main/java/com/kurierfree/server/domain/auth/infra/JwtGenerator.java
+++ b/src/main/java/com/kurierfree/server/domain/auth/infra/JwtGenerator.java
@@ -10,11 +10,12 @@ import java.util.Date;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import static com.kurierfree.server.domain.auth.constant.JwtGrantType.GRANT_TYPE_USER;
+import static com.kurierfree.server.domain.auth.constant.JwtTokenExpireTime.ACCESS_TOKEN_EXPIRE_TIME;
+import static com.kurierfree.server.domain.auth.constant.JwtTokenExpireTime.REFRESH_TOKEN_EXPIRE_TIME;
+
 @Component
 public class JwtGenerator {
-    private static final long ACCESS_TOKEN_EXPIRE_TIME = 86400000;
-    private static final long REFRESH_TOKEN_EXPIRE_TIME = 86400000;
-    private static final String GRANT_TYPE = "USER";
 
     private final Key key;
 
@@ -25,13 +26,13 @@ public class JwtGenerator {
     }
 
     // Member 정보를 가지고 AccessToken, RefreshToken을 생성하는 메서드
-    public JwtToken generateToken(Long userId) {
+    public JwtToken generateToken(Long userId, String grantType) {
         // 권한 가져오기
 
         long now = (new Date()).getTime();
 
         // Access Token 생성
-        Date accessTokenExpiresIn = new Date(now + ACCESS_TOKEN_EXPIRE_TIME);
+        Date accessTokenExpiresIn = new Date(now + ACCESS_TOKEN_EXPIRE_TIME.getExpireTime());
 
         String accessToken = Jwts.builder()
                 .setSubject(String.valueOf(userId))
@@ -42,12 +43,12 @@ public class JwtGenerator {
 
         // Refresh Token 생성
         String refreshToken = Jwts.builder()
-                .setExpiration(new Date(now + REFRESH_TOKEN_EXPIRE_TIME))
+                .setExpiration(new Date(now + REFRESH_TOKEN_EXPIRE_TIME.getExpireTime()))
                 .signWith(key, SignatureAlgorithm.HS256)
                 .compact();
 
         return JwtToken.builder()
-                .grantType(GRANT_TYPE)
+                .grantType(grantType)
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
                 .build();

--- a/src/main/java/com/kurierfree/server/domain/auth/infra/JwtProvider.java
+++ b/src/main/java/com/kurierfree/server/domain/auth/infra/JwtProvider.java
@@ -71,7 +71,6 @@ public class JwtProvider {
         return false;
     }
 
-
     // accessToken
     private Claims parseClaims(String accessToken) {
         try {

--- a/src/main/java/com/kurierfree/server/domain/lesson/dao/LessonRepository.java
+++ b/src/main/java/com/kurierfree/server/domain/lesson/dao/LessonRepository.java
@@ -1,0 +1,7 @@
+package com.kurierfree.server.domain.lesson.dao;
+
+import com.kurierfree.server.domain.lesson.domain.Lesson;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LessonRepository extends JpaRepository<Lesson, Long> {
+}

--- a/src/main/java/com/kurierfree/server/domain/lesson/dao/LessonRepository.java
+++ b/src/main/java/com/kurierfree/server/domain/lesson/dao/LessonRepository.java
@@ -3,5 +3,8 @@ package com.kurierfree.server.domain.lesson.dao;
 import com.kurierfree.server.domain.lesson.domain.Lesson;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface LessonRepository extends JpaRepository<Lesson, Long> {
+    List<Lesson> findByTimeTableId(Long timeTableId);
 }

--- a/src/main/java/com/kurierfree/server/domain/lesson/domain/ClassDay.java
+++ b/src/main/java/com/kurierfree/server/domain/lesson/domain/ClassDay.java
@@ -1,0 +1,9 @@
+package com.kurierfree.server.domain.lesson.domain;
+
+public enum ClassDay {
+    MONDAY,
+    TUESDAY,
+    WEDNESDAY,
+    THURSDAY,
+    FRIDAY;
+}

--- a/src/main/java/com/kurierfree/server/domain/lesson/domain/ClassTime.java
+++ b/src/main/java/com/kurierfree/server/domain/lesson/domain/ClassTime.java
@@ -1,0 +1,36 @@
+package com.kurierfree.server.domain.lesson.domain;
+
+import jakarta.persistence.Embeddable;
+import lombok.Getter;
+
+@Embeddable
+@Getter
+public class ClassTime {
+    private final int hour;
+    private final int minute;
+
+    private ClassTime(int hour, int minute) {
+        this.hour = hour;
+        this.minute = minute;
+    }
+
+    public static ClassTime of(int hour, int minute) {
+        validClassTime(hour, minute);
+        return new ClassTime(hour, minute);
+    }
+
+    private static void validClassTime(int hour, int minute) {
+        if (hour < 0 || hour > 23) {
+            throw new IllegalArgumentException("Hour must be between 0 and 23");
+        }
+        if (minute < 0 || minute > 59) {
+            throw new IllegalArgumentException("Minute must be between 0 and 59");
+        }
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%02d:%02d", hour, minute);
+    }
+
+}

--- a/src/main/java/com/kurierfree/server/domain/lesson/domain/ClassTime.java
+++ b/src/main/java/com/kurierfree/server/domain/lesson/domain/ClassTime.java
@@ -6,8 +6,12 @@ import lombok.Getter;
 @Embeddable
 @Getter
 public class ClassTime {
-    private final int hour;
-    private final int minute;
+    private int hour;
+    private int minute;
+
+    // 임베디드 클래스를 사용할 때는 기본 생성자가 반드시 필요
+    // JPA가 리플렉션(reflection)을 통해 객체를 생성할 수 있도록 하기 위해
+    public ClassTime(){} // 기본 생성자 추가
 
     private ClassTime(int hour, int minute) {
         this.hour = hour;

--- a/src/main/java/com/kurierfree/server/domain/lesson/domain/Lesson.java
+++ b/src/main/java/com/kurierfree/server/domain/lesson/domain/Lesson.java
@@ -28,6 +28,9 @@ public class Lesson {
     private String professor;
 
     @Column(nullable = false)
+    private String classroom;
+
+    @Column(nullable = false)
     private ClassDay classDay;
 
     @Embedded
@@ -45,19 +48,21 @@ public class Lesson {
     private ClassTime endTime;
 
     @Builder
-    private Lesson(TimeTable timeTable, String subject, String professor, ClassDay classDay, ClassTime startTime, ClassTime endTime) {
+    private Lesson(TimeTable timeTable, String subject, String professor, String classroom, ClassDay classDay, ClassTime startTime, ClassTime endTime) {
         this.timeTable = timeTable;
         this.subject = subject;
         this.professor = professor;
+        this.classroom = classroom;
         this.classDay = classDay;
         this.startTime = startTime;
         this.endTime = endTime;
     }
 
-    public static Lesson of(String subject, String professor, ClassDay classDay, ClassTime startTime, ClassTime endTime) {
+    public static Lesson of(String subject, String professor, String classroom, ClassDay classDay, ClassTime startTime, ClassTime endTime) {
         return Lesson.builder()
                 .subject(subject)
                 .professor(professor)
+                .classroom(classroom)
                 .classDay(classDay)
                 .startTime(startTime)
                 .endTime(endTime)

--- a/src/main/java/com/kurierfree/server/domain/lesson/domain/Lesson.java
+++ b/src/main/java/com/kurierfree/server/domain/lesson/domain/Lesson.java
@@ -30,12 +30,18 @@ public class Lesson {
     @Column(nullable = false)
     private ClassDay classDay;
 
-    @Column(nullable = false)
     @Embedded
+    @AttributeOverrides({
+            @AttributeOverride(name = "hour", column = @Column(name = "start_hour", nullable = false)),
+            @AttributeOverride(name = "minute", column = @Column(name = "start_minute", nullable = false))
+    })
     private ClassTime startTime;
 
-    @Column(nullable = false)
     @Embedded
+    @AttributeOverrides({
+            @AttributeOverride(name = "hour", column = @Column(name = "end_hour", nullable = false)),
+            @AttributeOverride(name = "minute", column = @Column(name = "end_minute", nullable = false))
+    })
     private ClassTime endTime;
 
     @Builder

--- a/src/main/java/com/kurierfree/server/domain/lesson/domain/Lesson.java
+++ b/src/main/java/com/kurierfree/server/domain/lesson/domain/Lesson.java
@@ -28,16 +28,18 @@ public class Lesson {
     private String professor;
 
     @Column(nullable = false)
-    private String classDay;
+    private ClassDay classDay;
 
     @Column(nullable = false)
-    private String startTime;
+    @Embedded
+    private ClassTime startTime;
 
     @Column(nullable = false)
-    private String endTime;
+    @Embedded
+    private ClassTime endTime;
 
     @Builder
-    private Lesson(TimeTable timeTable, String subject, String professor, String classDay, String startTime, String endTime) {
+    private Lesson(TimeTable timeTable, String subject, String professor, ClassDay classDay, ClassTime startTime, ClassTime endTime) {
         this.timeTable = timeTable;
         this.subject = subject;
         this.professor = professor;
@@ -46,7 +48,7 @@ public class Lesson {
         this.endTime = endTime;
     }
 
-    public static Lesson of(String subject, String professor, String classDay, String startTime, String endTime) {
+    public static Lesson of(String subject, String professor, ClassDay classDay, ClassTime startTime, ClassTime endTime) {
         return Lesson.builder()
                 .subject(subject)
                 .professor(professor)

--- a/src/main/java/com/kurierfree/server/domain/lesson/domain/Lesson.java
+++ b/src/main/java/com/kurierfree/server/domain/lesson/domain/Lesson.java
@@ -1,0 +1,59 @@
+package com.kurierfree.server.domain.lesson.domain;
+
+import com.kurierfree.server.domain.timeTable.domain.TimeTable;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "lesson")
+public class Lesson {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "time_table_id", nullable = false)
+    private TimeTable timeTable;
+
+    @Column(nullable = false)
+    private String subject;
+
+    @Column(nullable = false)
+    private String professor;
+
+    @Column(nullable = false)
+    private String classDay;
+
+    @Column(nullable = false)
+    private String startTime;
+
+    @Column(nullable = false)
+    private String endTime;
+
+    @Builder
+    private Lesson(TimeTable timeTable, String subject, String professor, String classDay, String startTime, String endTime) {
+        this.timeTable = timeTable;
+        this.subject = subject;
+        this.professor = professor;
+        this.classDay = classDay;
+        this.startTime = startTime;
+        this.endTime = endTime;
+    }
+
+    public static Lesson of(String subject, String professor, String classDay, String startTime, String endTime) {
+        return Lesson.builder()
+                .subject(subject)
+                .professor(professor)
+                .classDay(classDay)
+                .startTime(startTime)
+                .endTime(endTime)
+                .build();
+    }
+
+}

--- a/src/main/java/com/kurierfree/server/domain/lesson/dto/response/LessonResponse.java
+++ b/src/main/java/com/kurierfree/server/domain/lesson/dto/response/LessonResponse.java
@@ -1,7 +1,6 @@
 package com.kurierfree.server.domain.lesson.dto.response;
 
 import com.kurierfree.server.domain.lesson.domain.ClassDay;
-import com.kurierfree.server.domain.lesson.domain.ClassTime;
 import com.kurierfree.server.domain.lesson.domain.Lesson;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -15,8 +14,8 @@ public class LessonResponse {
     private String subject;
     private String professor;
     private ClassDay classDay;
-    private ClassTime startTime;
-    private ClassTime endTime;
+    private String startTime;
+    private String endTime;
 
     public static LessonResponse from(Lesson lesson) {
         return LessonResponse.builder()
@@ -24,8 +23,8 @@ public class LessonResponse {
                 .subject(lesson.getSubject())
                 .professor(lesson.getProfessor())
                 .classDay(lesson.getClassDay())
-                .startTime(lesson.getStartTime())
-                .endTime(lesson.getEndTime())
+                .startTime(lesson.getStartTime().toString())
+                .endTime(lesson.getEndTime().toString())
                 .build();
     }
 }

--- a/src/main/java/com/kurierfree/server/domain/lesson/dto/response/LessonResponse.java
+++ b/src/main/java/com/kurierfree/server/domain/lesson/dto/response/LessonResponse.java
@@ -3,7 +3,6 @@ package com.kurierfree.server.domain.lesson.dto.response;
 import com.kurierfree.server.domain.lesson.domain.ClassDay;
 import com.kurierfree.server.domain.lesson.domain.ClassTime;
 import com.kurierfree.server.domain.lesson.domain.Lesson;
-import com.kurierfree.server.domain.timeTable.domain.TimeTable;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,7 +12,6 @@ import lombok.Getter;
 @AllArgsConstructor
 public class LessonResponse {
     private Long id;
-    private TimeTable timeTable;
     private String subject;
     private String professor;
     private ClassDay classDay;
@@ -23,7 +21,6 @@ public class LessonResponse {
     public static LessonResponse from(Lesson lesson) {
         return LessonResponse.builder()
                 .id(lesson.getId())
-                .timeTable(lesson.getTimeTable())
                 .subject(lesson.getSubject())
                 .professor(lesson.getProfessor())
                 .classDay(lesson.getClassDay())

--- a/src/main/java/com/kurierfree/server/domain/lesson/dto/response/LessonResponse.java
+++ b/src/main/java/com/kurierfree/server/domain/lesson/dto/response/LessonResponse.java
@@ -1,0 +1,34 @@
+package com.kurierfree.server.domain.lesson.dto.response;
+
+import com.kurierfree.server.domain.lesson.domain.ClassDay;
+import com.kurierfree.server.domain.lesson.domain.ClassTime;
+import com.kurierfree.server.domain.lesson.domain.Lesson;
+import com.kurierfree.server.domain.timeTable.domain.TimeTable;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class LessonResponse {
+    private Long id;
+    private TimeTable timeTable;
+    private String subject;
+    private String professor;
+    private ClassDay classDay;
+    private ClassTime startTime;
+    private ClassTime endTime;
+
+    public static LessonResponse from(Lesson lesson) {
+        return LessonResponse.builder()
+                .id(lesson.getId())
+                .timeTable(lesson.getTimeTable())
+                .subject(lesson.getSubject())
+                .professor(lesson.getProfessor())
+                .classDay(lesson.getClassDay())
+                .startTime(lesson.getStartTime())
+                .endTime(lesson.getEndTime())
+                .build();
+    }
+}

--- a/src/main/java/com/kurierfree/server/domain/lesson/dto/response/LessonResponse.java
+++ b/src/main/java/com/kurierfree/server/domain/lesson/dto/response/LessonResponse.java
@@ -13,6 +13,7 @@ public class LessonResponse {
     private Long id;
     private String subject;
     private String professor;
+    private String classroom;
     private ClassDay classDay;
     private String startTime;
     private String endTime;
@@ -22,6 +23,7 @@ public class LessonResponse {
                 .id(lesson.getId())
                 .subject(lesson.getSubject())
                 .professor(lesson.getProfessor())
+                .classroom(lesson.getClassroom())
                 .classDay(lesson.getClassDay())
                 .startTime(lesson.getStartTime().toString())
                 .endTime(lesson.getEndTime().toString())

--- a/src/main/java/com/kurierfree/server/domain/timeTable/api/TimeTableApi.java
+++ b/src/main/java/com/kurierfree/server/domain/timeTable/api/TimeTableApi.java
@@ -1,0 +1,31 @@
+package com.kurierfree.server.domain.timeTable.api;
+
+import com.kurierfree.server.domain.timeTable.application.TimeTableService;
+import com.kurierfree.server.domain.timeTable.dto.response.TimeTableResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.persistence.EntityNotFoundException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/admin")
+public class TimeTableApi {
+    private final TimeTableService timeTableService;
+
+    public TimeTableApi(TimeTableService timeTableService) {
+        this.timeTableService = timeTableService;
+    }
+
+    @GetMapping("/timetable")
+    @Operation(summary = "시간표 가져오기")
+    public ResponseEntity<TimeTableResponse> getTimeTable(@RequestHeader("Authorization") String token) {
+        try{
+            TimeTableResponse timeTable = timeTableService.getTimeTable(token);
+            return ResponseEntity.ok(timeTable);
+        } catch (EntityNotFoundException e){
+            return ResponseEntity.notFound().build();
+        } catch (IllegalStateException e){
+            return ResponseEntity.internalServerError().build();
+        }
+    }
+}

--- a/src/main/java/com/kurierfree/server/domain/timeTable/application/TimeTableService.java
+++ b/src/main/java/com/kurierfree/server/domain/timeTable/application/TimeTableService.java
@@ -1,0 +1,53 @@
+package com.kurierfree.server.domain.timeTable.application;
+
+import com.kurierfree.server.domain.auth.infra.JwtProvider;
+import com.kurierfree.server.domain.lesson.dao.LessonRepository;
+import com.kurierfree.server.domain.lesson.dto.response.LessonResponse;
+import com.kurierfree.server.domain.semester.application.SemesterService;
+import com.kurierfree.server.domain.timeTable.dao.TimeTableRepository;
+import com.kurierfree.server.domain.timeTable.domain.TimeTable;
+import com.kurierfree.server.domain.timeTable.dto.response.TimeTableResponse;
+import jakarta.persistence.EntityNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+public class TimeTableService {
+    private final TimeTableRepository timeTableRepository;
+    private final LessonRepository lessonRepository;
+    private final SemesterService semesterService;
+    private final JwtProvider jwtProvider;
+
+    public TimeTableService(TimeTableRepository timeTableRepository, LessonRepository lessonRepository, SemesterService semesterService, JwtProvider jwtProvider) {
+        this.timeTableRepository = timeTableRepository;
+        this.lessonRepository = lessonRepository;
+        this.semesterService = semesterService;
+        this.jwtProvider = jwtProvider;
+    }
+
+    @Transactional
+    public TimeTableResponse getTimeTable(String token) {
+        String jwtToken = token.substring(7);
+        Long userId = jwtProvider.getUserIdFromToken(jwtToken);
+
+        TimeTable timeTable= timeTableRepository.findByUserIdAndSemesterId(
+                userId, semesterService.getCurrentSemester().getId()
+        );
+        if (timeTable == null) {
+            throw new EntityNotFoundException("TimeTable not found for userId: " + userId);
+
+        }
+
+        List<LessonResponse> lessonResponseList = lessonRepository.findByTimeTableId(timeTable.getId())
+                .stream()
+                .map(LessonResponse::from)
+                .toList();
+
+        return TimeTableResponse.builder()
+                .lessons(lessonResponseList)
+                .build();
+    }
+
+}

--- a/src/main/java/com/kurierfree/server/domain/timeTable/dao/TimeTableRepository.java
+++ b/src/main/java/com/kurierfree/server/domain/timeTable/dao/TimeTableRepository.java
@@ -4,4 +4,5 @@ import com.kurierfree.server.domain.timeTable.domain.TimeTable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TimeTableRepository extends JpaRepository<TimeTable, Long> {
+    TimeTable findByUserIdAndSemesterId(Long userId, Long semesterId);
 }

--- a/src/main/java/com/kurierfree/server/domain/timeTable/dao/TimeTableRepository.java
+++ b/src/main/java/com/kurierfree/server/domain/timeTable/dao/TimeTableRepository.java
@@ -1,0 +1,7 @@
+package com.kurierfree.server.domain.timeTable.dao;
+
+import com.kurierfree.server.domain.timeTable.domain.TimeTable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TimeTableRepository extends JpaRepository<TimeTable, Long> {
+}

--- a/src/main/java/com/kurierfree/server/domain/timeTable/domain/TimeTable.java
+++ b/src/main/java/com/kurierfree/server/domain/timeTable/domain/TimeTable.java
@@ -1,0 +1,41 @@
+package com.kurierfree.server.domain.timeTable.domain;
+
+import com.kurierfree.server.domain.semester.domain.Semester;
+import com.kurierfree.server.domain.user.domain.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "time_table")
+public class TimeTable {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "semester_id", nullable = false)
+    private Semester semester;
+
+    @Builder
+    private TimeTable( User user, Semester semester) {
+        this.user = user;
+        this.semester = semester;
+    }
+
+    public static TimeTable of(User user, Semester semester) {
+        return TimeTable.builder()
+                .user(user)
+                .semester(semester)
+                .build();
+    }
+}

--- a/src/main/java/com/kurierfree/server/domain/timeTable/dto/response/TimeTableResponse.java
+++ b/src/main/java/com/kurierfree/server/domain/timeTable/dto/response/TimeTableResponse.java
@@ -1,0 +1,15 @@
+package com.kurierfree.server.domain.timeTable.dto.response;
+
+import com.kurierfree.server.domain.lesson.dto.response.LessonResponse;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class TimeTableResponse {
+    private List<LessonResponse> lessons;
+}

--- a/src/main/java/com/kurierfree/server/domain/user/application/UserService.java
+++ b/src/main/java/com/kurierfree/server/domain/user/application/UserService.java
@@ -1,5 +1,6 @@
 package com.kurierfree.server.domain.user.application;
 
+import com.kurierfree.server.domain.auth.constant.JwtGrantType;
 import com.kurierfree.server.domain.auth.domain.JwtToken;
 import com.kurierfree.server.domain.auth.infra.JwtGenerator;
 import com.kurierfree.server.domain.auth.infra.JwtProvider;
@@ -102,7 +103,7 @@ public class UserService {
         User user = userRepository.findByStudentId(userLoginRequest.getStudentId())
                 .orElseThrow(() -> new EntityNotFoundException("해당 아이디를 가진 사용자가 존재하지 않습니다."));
 
-        JwtToken jwtToken = jwtGenerator.generateToken(user.getId());
+        JwtToken jwtToken = jwtGenerator.generateToken(user.getId(), JwtGrantType.GRANT_TYPE_USER.getValue());
 
         if (!passwordEncoder.matches(userLoginRequest.getPassword(), user.getPassword())){
             throw new BadCredentialsException("비밀번호가 일치하지 않습니다.");

--- a/src/main/java/com/kurierfree/server/domain/user/domain/enums/DisabilityType.java
+++ b/src/main/java/com/kurierfree/server/domain/user/domain/enums/DisabilityType.java
@@ -1,5 +1,8 @@
 package com.kurierfree.server.domain.user.domain.enums;
 
+import lombok.Getter;
+
+@Getter
 public enum DisabilityType {
     PHYSICAL_DISABILITY("지체장애"),
     HEARING_DISABILITY("청각장애"),
@@ -11,10 +14,6 @@ public enum DisabilityType {
 
     DisabilityType(String description) {
         this.description = description;
-    }
-
-    public String getDescription() {
-        return description;
     }
 
 }


### PR DESCRIPTION
### 🥕 Title
Feat: register, login, logout api
issue #4  시간표 조회 API
---

### ✅ Key Changes
- timetable, lesson(수업, class가 예약어라...) entity 및 repository 구현
- 시간표 조회 api 구현
---

### 📢 To Reviewers
- 시간표 생성 api 가 아직 없어서 시간표 조회 api 테스트는 직접 db에서 생성후 가능함
- 왠진 모르겠지만 토큰 관련 api 테스트가 스웨거가 안 되어서,, postman은 됩니다 ㅜㅜ
- admin해야됨! :  id/pw 지정하고 grant type admin 인 토큰 반환