### PR TITLE
Feat: 매칭 api

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ jobs:
         echo -e "${{ secrets.APPLICATION }}" >> ./src/main/resources/application.yml
 
     - name: Gradle 빌드
-      run: ./gradlew clean bootJar -x test
+      run: ./gradlew clean build -x test
 
              # Docker 이미지를 빌드하기 전에 정리 단계 추가
     - name: Clean up Docker to free space

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,6 +19,12 @@ jobs:
         distribution: 'temurin'
         java-version: '21'
 
+    - name:  Setup Environment
+      run: |
+        mkdir -p ./src/main/resources
+        touch ./src/main/resources/application.yml
+        echo -e "${{ secrets.APPLICATION }}" >> ./src/main/resources/application.yml
+
     - name: Gradle 빌드
       run: ./gradlew clean build -x test
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,11 +22,10 @@ jobs:
     - name:  Setup Environment
       run: |
         mkdir -p ./src/main/resources
-        touch ./src/main/resources/application.yml
         echo -e "${{ secrets.APPLICATION }}" >> ./src/main/resources/application.yml
 
     - name: Gradle 빌드
-      run: ./gradlew clean build -x test
+      run: ./gradlew clean bootJar -x test
 
              # Docker 이미지를 빌드하기 전에 정리 단계 추가
     - name: Clean up Docker to free space

--- a/src/main/java/com/kurierfree/server/domain/auth/Interceptor/AuthInterceptor.java
+++ b/src/main/java/com/kurierfree/server/domain/auth/Interceptor/AuthInterceptor.java
@@ -1,0 +1,68 @@
+package com.kurierfree.server.domain.auth.Interceptor;
+
+import com.kurierfree.server.domain.auth.infra.JwtProvider;
+import com.kurierfree.server.domain.user.dao.UserRepository;
+import com.kurierfree.server.domain.user.domain.User;
+import com.kurierfree.server.domain.user.domain.enums.Role;
+import jakarta.persistence.EntityNotFoundException;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+
+@Component
+public class AuthInterceptor implements HandlerInterceptor {
+    private final JwtProvider jwtProvider;
+    private final UserRepository userRepository;
+
+    public AuthInterceptor(JwtProvider jwtProvider, UserRepository userRepository) {
+        this.jwtProvider = jwtProvider;
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        String path = request.getRequestURI();
+
+        // /api/admin으로 시작하는 요청만 토큰 검사를 진행
+        if (path.startsWith("/api/admin")) {
+            return !validateAdminLogin(request, response); // 요청을 중단
+        }
+
+        return true; // 요청을 계속 진행
+    }
+
+    private boolean validateAdminLogin(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        String token = request.getHeader("Authorization");
+
+        // 토큰이 없거나 형식이 잘못된 경우
+        if (token == null || !token.startsWith("Bearer ")) {
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "토큰이 필요합니다.");
+            return true;
+        }
+
+        String jwtToken = token.substring(7); // "Bearer "를 제외한 토큰
+        Long userId = jwtProvider.getUserIdFromToken(jwtToken);
+
+        // 사용자 존재 여부 및 역할 확인
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> {
+                    try {
+                        response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "사용자를 찾을 수 없습니다.");
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                    return new EntityNotFoundException();
+                });
+
+        if (user.getRole() != Role.ADMIN) {
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "관리자만 접근할 수 있습니다.");
+            return true;
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/kurierfree/server/domain/lesson/dao/LessonRepository.java
+++ b/src/main/java/com/kurierfree/server/domain/lesson/dao/LessonRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface LessonRepository extends JpaRepository<Lesson, Long> {
-    List<Lesson> findByTimeTableId(Long timeTableId);
+    //List<Lesson> findByTimeTableId(Long timeTableId);
 }

--- a/src/main/java/com/kurierfree/server/domain/lesson/domain/Lesson.java
+++ b/src/main/java/com/kurierfree/server/domain/lesson/domain/Lesson.java
@@ -25,7 +25,6 @@ public class Lesson {
     @Column(nullable = false)
     private String professor;
 
-
     @OneToMany(mappedBy = "lesson", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<LessonSchedule> lessonSchedules = new ArrayList<>();
 

--- a/src/main/java/com/kurierfree/server/domain/lesson/domain/Lesson.java
+++ b/src/main/java/com/kurierfree/server/domain/lesson/domain/Lesson.java
@@ -30,6 +30,7 @@ public class Lesson {
     @Column(nullable = false)
     private String classroom;
 
+    @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private ClassDay classDay;
 

--- a/src/main/java/com/kurierfree/server/domain/lesson/domain/Lesson.java
+++ b/src/main/java/com/kurierfree/server/domain/lesson/domain/Lesson.java
@@ -1,11 +1,13 @@
 package com.kurierfree.server.domain.lesson.domain;
 
-import com.kurierfree.server.domain.timeTable.domain.TimeTable;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -17,57 +19,31 @@ public class Lesson {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "time_table_id", nullable = false)
-    private TimeTable timeTable;
-
     @Column(nullable = false)
     private String subject;
 
     @Column(nullable = false)
     private String professor;
 
-    @Column(nullable = false)
-    private String classroom;
 
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
-    private ClassDay classDay;
-
-    @Embedded
-    @AttributeOverrides({
-            @AttributeOverride(name = "hour", column = @Column(name = "start_hour", nullable = false)),
-            @AttributeOverride(name = "minute", column = @Column(name = "start_minute", nullable = false))
-    })
-    private ClassTime startTime;
-
-    @Embedded
-    @AttributeOverrides({
-            @AttributeOverride(name = "hour", column = @Column(name = "end_hour", nullable = false)),
-            @AttributeOverride(name = "minute", column = @Column(name = "end_minute", nullable = false))
-    })
-    private ClassTime endTime;
+    @OneToMany(mappedBy = "lesson", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<LessonSchedule> lessonSchedules = new ArrayList<>();
 
     @Builder
-    private Lesson(TimeTable timeTable, String subject, String professor, String classroom, ClassDay classDay, ClassTime startTime, ClassTime endTime) {
-        this.timeTable = timeTable;
+    private Lesson(String subject, String professor) {
         this.subject = subject;
         this.professor = professor;
-        this.classroom = classroom;
-        this.classDay = classDay;
-        this.startTime = startTime;
-        this.endTime = endTime;
     }
 
-    public static Lesson of(String subject, String professor, String classroom, ClassDay classDay, ClassTime startTime, ClassTime endTime) {
+    public static Lesson of(String subject, String professor) {
         return Lesson.builder()
                 .subject(subject)
                 .professor(professor)
-                .classroom(classroom)
-                .classDay(classDay)
-                .startTime(startTime)
-                .endTime(endTime)
                 .build();
     }
 
+    public void addLessonSchedules(LessonSchedule lessonSchedule) {
+        this.lessonSchedules.add(lessonSchedule);
+        lessonSchedule.setLesson(this);
+    }
 }

--- a/src/main/java/com/kurierfree/server/domain/lesson/domain/LessonSchedule.java
+++ b/src/main/java/com/kurierfree/server/domain/lesson/domain/LessonSchedule.java
@@ -1,0 +1,58 @@
+package com.kurierfree.server.domain.lesson.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class LessonSchedule {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String classroom;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ClassDay classDay;
+
+    @Embedded
+    @AttributeOverrides({
+            @AttributeOverride(name = "hour", column = @Column(name = "start_hour", nullable = false)),
+            @AttributeOverride(name = "minute", column = @Column(name = "start_minute", nullable = false))
+    })
+    private ClassTime startTime;
+
+    @Embedded
+    @AttributeOverrides({
+            @AttributeOverride(name = "hour", column = @Column(name = "end_hour", nullable = false)),
+            @AttributeOverride(name = "minute", column = @Column(name = "end_minute", nullable = false))
+    })
+    private ClassTime endTime;
+
+    @Setter
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "lesson_id", nullable = false)
+    private Lesson lesson;
+
+    @Builder
+    public LessonSchedule(String classroom, ClassDay classDay, ClassTime startTime, ClassTime endTime) {
+        this.classroom = classroom;
+        this.classDay = classDay;
+        this.startTime = startTime;
+        this.endTime = endTime;
+    }
+
+    public static LessonSchedule of(String classroom, ClassDay classDay, ClassTime startTime, ClassTime endTime){
+        return LessonSchedule.builder()
+                .classroom(classroom)
+                .classDay(classDay)
+                .startTime(startTime)
+                .endTime(endTime)
+                .build();
+    }
+
+}

--- a/src/main/java/com/kurierfree/server/domain/lesson/dto/response/LessonResponse.java
+++ b/src/main/java/com/kurierfree/server/domain/lesson/dto/response/LessonResponse.java
@@ -1,10 +1,11 @@
 package com.kurierfree.server.domain.lesson.dto.response;
 
-import com.kurierfree.server.domain.lesson.domain.ClassDay;
 import com.kurierfree.server.domain.lesson.domain.Lesson;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+
+import java.util.List;
 
 @Getter
 @Builder
@@ -13,20 +14,14 @@ public class LessonResponse {
     private Long id;
     private String subject;
     private String professor;
-    private String classroom;
-    private ClassDay classDay;
-    private String startTime;
-    private String endTime;
+    private List<LessonScheduleResponse> lessonSchedule;
 
-    public static LessonResponse from(Lesson lesson) {
+    public static LessonResponse from(Lesson lesson, List<LessonScheduleResponse> lessonScheduleResponse) {
         return LessonResponse.builder()
                 .id(lesson.getId())
                 .subject(lesson.getSubject())
                 .professor(lesson.getProfessor())
-                .classroom(lesson.getClassroom())
-                .classDay(lesson.getClassDay())
-                .startTime(lesson.getStartTime().toString())
-                .endTime(lesson.getEndTime().toString())
+                .lessonSchedule(lessonScheduleResponse)
                 .build();
     }
 }

--- a/src/main/java/com/kurierfree/server/domain/lesson/dto/response/LessonScheduleResponse.java
+++ b/src/main/java/com/kurierfree/server/domain/lesson/dto/response/LessonScheduleResponse.java
@@ -1,0 +1,26 @@
+package com.kurierfree.server.domain.lesson.dto.response;
+
+import com.kurierfree.server.domain.lesson.domain.ClassDay;
+import com.kurierfree.server.domain.lesson.domain.LessonSchedule;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class LessonScheduleResponse {
+    private String classroom;
+    private ClassDay classDay;
+    private String startTime;
+    private String endTime;
+
+    public static LessonScheduleResponse from(LessonSchedule lessonSchedule) {
+        return LessonScheduleResponse.builder()
+                .classDay(lessonSchedule.getClassDay())
+                .startTime(lessonSchedule.getStartTime().toString())
+                .endTime(lessonSchedule.getEndTime().toString())
+                .classroom(lessonSchedule.getClassroom())
+                .build();
+    }
+}

--- a/src/main/java/com/kurierfree/server/domain/list/api/ListApi.java
+++ b/src/main/java/com/kurierfree/server/domain/list/api/ListApi.java
@@ -41,7 +41,7 @@ public class ListApi {
     }
 
     @Operation(summary = "확정된 서포터즈 명단 조회",
-    description = "matched - true / matching - false")
+            description = "matched - true / matching - false")
     @GetMapping("/supporters")
     public ResponseEntity<List<SupporterResponse>> getSupporterList(@RequestHeader("Authorization") String token) {
         try {
@@ -59,29 +59,30 @@ public class ListApi {
     @Operation(summary = "선발된 서포터즈 명단 조회",
             description = "status: Matching 인 서포터즈 조회")
     @GetMapping("/supporters/matching")
-    public ResponseEntity<List<SupporterListItemResponse>> getMatchingSupporterList(@RequestHeader("Authorization") String token){
-        try{
+    public ResponseEntity<List<SupporterListItemResponse>> getMatchingSupporterList(@RequestHeader("Authorization") String token) {
+        try {
             List<SupporterListItemResponse> matchedSupporterResponses = listService.getMatchingSupportersForAdmin(token);
             return ResponseEntity.ok(matchedSupporterResponses);
-        } catch (AccessDeniedException e){
+        } catch (AccessDeniedException e) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
-        } catch (EntityNotFoundException e){
+        } catch (EntityNotFoundException e) {
             return ResponseEntity.notFound().build();
-        } catch (IllegalStateException e){
+        } catch (IllegalStateException e) {
             return ResponseEntity.internalServerError().build();
         }
     }
+
     @Operation(summary = "해당 학기 서포터즈 선택 완료 버튼")
     @PostMapping("/supporters/finalize")
-    public ResponseEntity<?> finalizeSupporters(@RequestHeader("Authorization") String token){
-        try{
+    public ResponseEntity<?> finalizeSupporters(@RequestHeader("Authorization") String token) {
+        try {
             listService.finalizeSupportersForSemester(token);
             return ResponseEntity.ok(Map.of("message", "해당 학기 서포터즈 선택이 완료되었습니다."));
-        } catch (AccessDeniedException e){
+        } catch (AccessDeniedException e) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
-        } catch (EntityNotFoundException e){
+        } catch (EntityNotFoundException e) {
             return ResponseEntity.notFound().build();
-        } catch (IllegalStateException e){
+        } catch (IllegalStateException e) {
             return ResponseEntity.internalServerError().build();
         }
     }
@@ -89,15 +90,15 @@ public class ListApi {
     @Operation(summary = "서포터즈 지원자 명단 조회 ",
             description = "status: Pending || Rejected || Matching 인 서포터즈 조회")
     @GetMapping("/supporters/applied")
-    public ResponseEntity<List<SupporterListItemResponse>> getAppliedSupporterList(@RequestHeader("Authorization") String token){
-        try{
+    public ResponseEntity<List<SupporterListItemResponse>> getAppliedSupporterList(@RequestHeader("Authorization") String token) {
+        try {
             List<SupporterListItemResponse> matchedSupporterResponses = listService.getAppliedSupportersForAdmin(token);
             return ResponseEntity.ok(matchedSupporterResponses);
-        } catch (AccessDeniedException e){
+        } catch (AccessDeniedException e) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
-        } catch (EntityNotFoundException e){
+        } catch (EntityNotFoundException e) {
             return ResponseEntity.notFound().build();
-        } catch (IllegalStateException e){
+        } catch (IllegalStateException e) {
             return ResponseEntity.internalServerError().build();
         }
     }
@@ -106,15 +107,15 @@ public class ListApi {
             description = "서포터즈 선발 or 탈락 상태 변경")
     @PutMapping("/supporters/status")
     public ResponseEntity<?> updateSupporterStatus(@RequestHeader("Authorization") String token,
-                                                   @RequestBody SupporterStatusUpdateRequest request){
-        try{
+                                                   @RequestBody SupporterStatusUpdateRequest request) {
+        try {
             listService.updateSupporterStatus(token, request);
             return ResponseEntity.ok(Map.of("message", "서포터즈 상태가 성공적으로 업데이트되었습니다."));
-        }catch (AccessDeniedException e){
+        } catch (AccessDeniedException e) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
-        } catch (EntityNotFoundException e){
+        } catch (EntityNotFoundException e) {
             return ResponseEntity.notFound().build();
-        } catch (IllegalStateException e){
+        } catch (IllegalStateException e) {
             return ResponseEntity.internalServerError().build();
         }
     }

--- a/src/main/java/com/kurierfree/server/domain/matching/api/MatchingApi.java
+++ b/src/main/java/com/kurierfree/server/domain/matching/api/MatchingApi.java
@@ -1,0 +1,65 @@
+package com.kurierfree.server.domain.matching.api;
+
+import com.kurierfree.server.domain.matching.application.MatchingService;
+import com.kurierfree.server.domain.matching.dto.request.MatchingRequest;
+import com.kurierfree.server.domain.matching.dto.response.MatchingResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.persistence.EntityNotFoundException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/admin")
+public class MatchingApi {
+    private final MatchingService matchingService;
+
+    public MatchingApi(MatchingService matchingService) {
+        this.matchingService = matchingService;
+    }
+
+    @PostMapping("/matchings")
+    @Operation(summary = "매칭 확정")
+    public ResponseEntity<String> createMatching(@RequestBody MatchingRequest matchingRequest) {
+        try{
+            matchingService.createMatching(matchingRequest);
+            return ResponseEntity
+                    .status(HttpStatus.CREATED)
+                    .body("매칭이 성공적으로 완료되었습니다.");
+        } catch (AccessDeniedException e) {
+            return ResponseEntity
+                    .status(HttpStatus.FORBIDDEN)
+                    .body(e.getMessage());
+        }
+        catch (EntityNotFoundException e) {
+            return ResponseEntity
+                    .status(HttpStatus.NOT_FOUND)
+                    .body(e.getMessage());
+        }
+        catch (IllegalStateException e) {
+            return ResponseEntity
+                    .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(e.getMessage());
+        }
+    }
+
+    @GetMapping("/disabled-students/{disabledStudentsId}/matchings")
+    @Operation(summary = "장애학생 별 서포터즈 매칭 3순위 조회")
+    public ResponseEntity<MatchingResponse> getMatchingThirdPriorityOfDisabledStudent(@PathVariable Long disabledStudentsId) {
+        try{
+            MatchingResponse matchingResponse = matchingService.getMatchingThirdPriorityOfDisabledStudent(disabledStudentsId);
+            return ResponseEntity
+                    .status(HttpStatus.OK)
+                    .body(matchingResponse);
+        } catch (AccessDeniedException e) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
+        catch (EntityNotFoundException e) {
+            return ResponseEntity.notFound().build();
+        }
+        catch (IllegalStateException e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+}

--- a/src/main/java/com/kurierfree/server/domain/matching/application/MatchingService.java
+++ b/src/main/java/com/kurierfree/server/domain/matching/application/MatchingService.java
@@ -52,7 +52,7 @@ public class MatchingService {
         // 매칭이 완료된 장애학생-서포터즈 조합의 스코어 정보는 삭제
         matchingScoreCacheRepository.deleteBySupporterIdAndDisabledStudentId(supporter.getId(), disabledStudent.getId());
 
-        if (supporter.updateAndGetSupporterMatchCount() == 2){
+        if (!supporter.updateAndValidSupporterMatchCount()){
             supporter.updateStatusMatched();
 
             // 매칭이 끝난 서포터즈 -> 매칭 점수 계산 테이블에서 삭제

--- a/src/main/java/com/kurierfree/server/domain/matching/application/MatchingService.java
+++ b/src/main/java/com/kurierfree/server/domain/matching/application/MatchingService.java
@@ -1,24 +1,51 @@
 package com.kurierfree.server.domain.matching.application;
 
 import com.kurierfree.server.domain.matching.dao.MatchingRepository;
+import com.kurierfree.server.domain.matching.domain.Matching;
 import com.kurierfree.server.domain.matching.dto.request.MatchingRequest;
 import com.kurierfree.server.domain.matching.dto.response.MatchingResponse;
+import com.kurierfree.server.domain.semester.application.SemesterService;
+import com.kurierfree.server.domain.user.dao.DisabledStudentRepository;
+import com.kurierfree.server.domain.user.dao.SupporterRepository;
 import com.kurierfree.server.domain.user.dao.UserRepository;
+import com.kurierfree.server.domain.user.domain.DisabledStudent;
+import com.kurierfree.server.domain.user.domain.Supporter;
+import jakarta.persistence.EntityNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class MatchingService {
     private final MatchingRepository matchingRepository;
-    private final UserRepository userRepository;
+    private final SupporterRepository supporterRepository;
+    private final DisabledStudentRepository disabledStudentRepository;
+    private final SemesterService semesterService;
 
-    public MatchingService(MatchingRepository matchingRepository, UserRepository userRepository) {
+    public MatchingService(MatchingRepository matchingRepository, SupporterRepository supporterRepository, DisabledStudentRepository disabledStudentRepository, SemesterService semesterService) {
         this.matchingRepository = matchingRepository;
-        this.userRepository = userRepository;
+        this.supporterRepository = supporterRepository;
+        this.disabledStudentRepository = disabledStudentRepository;
+        this.semesterService = semesterService;
     }
 
     @Transactional
     public void createMatching(MatchingRequest matchingRequest) {
+        Supporter supporter = supporterRepository.findById(matchingRequest.getSupporterId())
+                .orElseThrow(() -> new EntityNotFoundException("해당 아이디를 가진 서포터즈가 존재하지 않습니다."));
+
+        DisabledStudent disabledStudent = disabledStudentRepository.findById(matchingRequest.getDisabledStudentId())
+                .orElseThrow(() -> new EntityNotFoundException("해당 아이디를 가진 장애학생이 존재하지 않습니다."));
+
+        Matching matching = Matching.builder()
+                .semester(semesterService.getCurrentSemester())
+                .supporter(supporter)
+                .disabledStudent(disabledStudent)
+                .build();
+
+        matchingRepository.save(matching);
+
+        supporter.updateStatusMatched();
+        disabledStudent.updateStatusMatched();
     }
 
     public MatchingResponse getMatchingThirdPriorityOfDisabledStudent(Long disabledStudentsId) {

--- a/src/main/java/com/kurierfree/server/domain/matching/application/MatchingService.java
+++ b/src/main/java/com/kurierfree/server/domain/matching/application/MatchingService.java
@@ -130,7 +130,6 @@ public class MatchingService {
         if (departmentMatch) score += 1;
         score += timeTableMatchScore;
 
-
         MatchingScoreCache matchingScoreCache = MatchingScoreCache.of(
                 disabledStudentsId,
                 supporterId,
@@ -145,7 +144,7 @@ public class MatchingService {
     }
 
     // 매칭 score 저장: 선발기간 시작시기에 맞춰 1회만 실행
-    //@PostConstruct // Todo: 스케줄링으로 바꾸기
+    @PostConstruct // Todo: 스케줄링으로 바꾸기
     public void initMatchingScoreRepository(){
         if (matchingScoreCacheRepository.count() != 0) {
             return;

--- a/src/main/java/com/kurierfree/server/domain/matching/application/MatchingService.java
+++ b/src/main/java/com/kurierfree/server/domain/matching/application/MatchingService.java
@@ -1,18 +1,25 @@
 package com.kurierfree.server.domain.matching.application;
 
 import com.kurierfree.server.domain.matching.dao.MatchingRepository;
+import com.kurierfree.server.domain.matching.dao.MatchingScoreCacheRepository;
 import com.kurierfree.server.domain.matching.domain.Matching;
+import com.kurierfree.server.domain.matching.domain.MatchingScoreCache;
 import com.kurierfree.server.domain.matching.dto.request.MatchingRequest;
 import com.kurierfree.server.domain.matching.dto.response.MatchingResponse;
+import com.kurierfree.server.domain.matching.dto.response.MatchingSupporters;
 import com.kurierfree.server.domain.semester.application.SemesterService;
 import com.kurierfree.server.domain.user.dao.DisabledStudentRepository;
 import com.kurierfree.server.domain.user.dao.SupporterRepository;
-import com.kurierfree.server.domain.user.dao.UserRepository;
 import com.kurierfree.server.domain.user.domain.DisabledStudent;
 import com.kurierfree.server.domain.user.domain.Supporter;
+import com.kurierfree.server.domain.user.domain.enums.Status;
+import jakarta.annotation.PostConstruct;
 import jakarta.persistence.EntityNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
 public class MatchingService {
@@ -20,12 +27,14 @@ public class MatchingService {
     private final SupporterRepository supporterRepository;
     private final DisabledStudentRepository disabledStudentRepository;
     private final SemesterService semesterService;
+    private final MatchingScoreCacheRepository matchingScoreCacheRepository;
 
-    public MatchingService(MatchingRepository matchingRepository, SupporterRepository supporterRepository, DisabledStudentRepository disabledStudentRepository, SemesterService semesterService) {
+    public MatchingService(MatchingRepository matchingRepository, SupporterRepository supporterRepository, DisabledStudentRepository disabledStudentRepository, SemesterService semesterService, MatchingScoreCacheRepository matchingScoreCacheRepository) {
         this.matchingRepository = matchingRepository;
         this.supporterRepository = supporterRepository;
         this.disabledStudentRepository = disabledStudentRepository;
         this.semesterService = semesterService;
+        this.matchingScoreCacheRepository = matchingScoreCacheRepository;
     }
 
     @Transactional
@@ -36,19 +45,97 @@ public class MatchingService {
         DisabledStudent disabledStudent = disabledStudentRepository.findById(matchingRequest.getDisabledStudentId())
                 .orElseThrow(() -> new EntityNotFoundException("해당 아이디를 가진 장애학생이 존재하지 않습니다."));
 
-        Matching matching = Matching.builder()
-                .semester(semesterService.getCurrentSemester())
-                .supporter(supporter)
-                .disabledStudent(disabledStudent)
-                .build();
+        matchingRepository.save(Matching.of(
+                semesterService.getCurrentSemester(),
+                supporter,
+                disabledStudent)
+        );
 
-        matchingRepository.save(matching);
+        if (supporter.updateAndGetSupporterMatchCount() == 2){
+            supporter.updateStatusMatched();
 
-        supporter.updateStatusMatched();
-        disabledStudent.updateStatusMatched();
+            // 매칭이 끝난 서포터즈 -> 매칭 점수 계산 테이블에서 삭제
+            matchingScoreCacheRepository.deleteBySupporterId(supporter.getId());
+
+            // Todo: 매칭이 끝난 서포터즈가 생기면 한 장애학생의 top3에만 유일하게 속하는 서포터즈가 있는지 확인
+
+        }
     }
 
+    @Transactional
     public MatchingResponse getMatchingThirdPriorityOfDisabledStudent(Long disabledStudentsId) {
-        return null;
+        List<MatchingScoreCache> matchingScoreCacheList = matchingScoreCacheRepository.findByDisabledStudentIdOrderByScoreDesc(disabledStudentsId);
+
+        List<MatchingSupporters> matchingSupportersList = matchingScoreCacheList.stream()
+                .limit(3) // 상위 3명만 선택
+                .map(matchingScoreCache -> {
+                    Supporter supporter = supporterRepository.findById(matchingScoreCache.getSupporterId())
+                            .orElseThrow(() -> new EntityNotFoundException("해당 아이디를 가진 서포터즈가 존재하지 않습니다."));
+
+                    return MatchingSupporters.builder()
+                            .rank(matchingScoreCacheList.indexOf(matchingScoreCache) + 1) // 현재 인덱스를 rank로 사용
+                            .supporterId(disabledStudentsId)
+                            .name(supporter.getName())
+                            .department(supporter.getDepartment())
+                            .gender(supporter.getGender())
+                            .grade(supporter.getGrade())
+                            .build();
+                })
+                .toList();
+
+        return MatchingResponse.builder()
+                .matchingSupporters(matchingSupportersList)
+                .build();
     }
+
+    // 매칭 스코어 계산 메소드
+    private void saveMatchingScore(Long disabledStudentsId, Long supporterId) {
+        DisabledStudent disabledStudent = disabledStudentRepository.findById(disabledStudentsId)
+                .orElseThrow(() -> new EntityNotFoundException("해당 아이디를 가진 장애학생이 존재하지 않습니다."));
+
+        Supporter supporter = supporterRepository.findById(supporterId)
+                .orElseThrow(() -> new EntityNotFoundException("해당 아이디를 가진 서포터즈가 존재하지 않습니다."));
+
+        // Todo: 사전 지정이라면 1순위로 만들기
+
+        int score = 0;
+
+        // Todo: 장애학생 수업시간 = 서포터즈 활동 가능시간인가
+        // Todo: 동일 과목 여부
+
+        // 동일 성별 여부
+        boolean genderMatch = supporter.getGender() == disabledStudent.getGender();
+
+        // 같은 학과 여부
+        boolean departmentMatch = supporter.getDepartment().equals(disabledStudent.getDepartment());
+
+        // 점수 계산
+        if (genderMatch) score += 3;
+        if (departmentMatch) score += 1;
+
+        MatchingScoreCache matchingScoreCache = MatchingScoreCache.of(
+                disabledStudentsId,
+                supporterId,
+                score,
+                genderMatch,
+                departmentMatch
+                );
+
+        matchingScoreCacheRepository.save(matchingScoreCache);
+    }
+
+    // 매칭 score 저장: 선발기간 시작시기에 맞춰 1회만 실행
+    @PostConstruct // Todo: 스케줄링으로 바꾸기
+    public void initMatchingScoreRepository(){
+        if (matchingScoreCacheRepository.count() != 0) {
+            return;
+        }
+
+        for (Long disabledStudentId : disabledStudentRepository.findAllIds()) {
+            for (Long supporterId : supporterRepository.findAllIds()) {
+                saveMatchingScore(disabledStudentId, supporterId);
+            }
+        }
+    }
+
 }

--- a/src/main/java/com/kurierfree/server/domain/matching/application/MatchingService.java
+++ b/src/main/java/com/kurierfree/server/domain/matching/application/MatchingService.java
@@ -12,13 +12,11 @@ import com.kurierfree.server.domain.user.dao.DisabledStudentRepository;
 import com.kurierfree.server.domain.user.dao.SupporterRepository;
 import com.kurierfree.server.domain.user.domain.DisabledStudent;
 import com.kurierfree.server.domain.user.domain.Supporter;
-import com.kurierfree.server.domain.user.domain.enums.Status;
 import jakarta.annotation.PostConstruct;
 import jakarta.persistence.EntityNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -50,6 +48,9 @@ public class MatchingService {
                 supporter,
                 disabledStudent)
         );
+
+        // 매칭이 완료된 장애학생-서포터즈 조합의 스코어 정보는 삭제
+        matchingScoreCacheRepository.deleteBySupporterIdAndDisabledStudentId(supporter.getId(), disabledStudent.getId());
 
         if (supporter.updateAndGetSupporterMatchCount() == 2){
             supporter.updateStatusMatched();

--- a/src/main/java/com/kurierfree/server/domain/matching/application/MatchingService.java
+++ b/src/main/java/com/kurierfree/server/domain/matching/application/MatchingService.java
@@ -145,7 +145,7 @@ public class MatchingService {
     }
 
     // 매칭 score 저장: 선발기간 시작시기에 맞춰 1회만 실행
-    @PostConstruct // Todo: 스케줄링으로 바꾸기
+    //@PostConstruct // Todo: 스케줄링으로 바꾸기
     public void initMatchingScoreRepository(){
         if (matchingScoreCacheRepository.count() != 0) {
             return;

--- a/src/main/java/com/kurierfree/server/domain/matching/application/MatchingService.java
+++ b/src/main/java/com/kurierfree/server/domain/matching/application/MatchingService.java
@@ -75,7 +75,7 @@ public class MatchingService {
 
                     return MatchingSupporters.builder()
                             .rank(matchingScoreCacheList.indexOf(matchingScoreCache) + 1) // 현재 인덱스를 rank로 사용
-                            .supporterId(disabledStudentsId)
+                            .supporterId(supporter.getId())
                             .name(supporter.getName())
                             .department(supporter.getDepartment())
                             .gender(supporter.getGender())

--- a/src/main/java/com/kurierfree/server/domain/matching/application/MatchingService.java
+++ b/src/main/java/com/kurierfree/server/domain/matching/application/MatchingService.java
@@ -1,0 +1,27 @@
+package com.kurierfree.server.domain.matching.application;
+
+import com.kurierfree.server.domain.matching.dao.MatchingRepository;
+import com.kurierfree.server.domain.matching.dto.request.MatchingRequest;
+import com.kurierfree.server.domain.matching.dto.response.MatchingResponse;
+import com.kurierfree.server.domain.user.dao.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class MatchingService {
+    private final MatchingRepository matchingRepository;
+    private final UserRepository userRepository;
+
+    public MatchingService(MatchingRepository matchingRepository, UserRepository userRepository) {
+        this.matchingRepository = matchingRepository;
+        this.userRepository = userRepository;
+    }
+
+    @Transactional
+    public void createMatching(MatchingRequest matchingRequest) {
+    }
+
+    public MatchingResponse getMatchingThirdPriorityOfDisabledStudent(Long disabledStudentsId) {
+        return null;
+    }
+}

--- a/src/main/java/com/kurierfree/server/domain/matching/dao/MatchingRepository.java
+++ b/src/main/java/com/kurierfree/server/domain/matching/dao/MatchingRepository.java
@@ -1,0 +1,7 @@
+package com.kurierfree.server.domain.matching.dao;
+
+import com.kurierfree.server.domain.matching.domain.Matching;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MatchingRepository extends JpaRepository<Matching, Long> {
+}

--- a/src/main/java/com/kurierfree/server/domain/matching/dao/MatchingScoreCacheRepository.java
+++ b/src/main/java/com/kurierfree/server/domain/matching/dao/MatchingScoreCacheRepository.java
@@ -9,4 +9,8 @@ public interface MatchingScoreCacheRepository extends JpaRepository<MatchingScor
     void deleteBySupporterId(Long supporterId); // 매칭 확정된 서포터즈 제거 시 사용
 
     void deleteBySupporterIdAndDisabledStudentId(Long supporterId, Long disabledStudentId);
+
+    MatchingScoreCache findByDisabledStudentIdAndSupporterId(Long disabledStudentId, Long supporterId);
+    List<MatchingScoreCache> findBySupporterId(Long supporterId);
+
 }

--- a/src/main/java/com/kurierfree/server/domain/matching/dao/MatchingScoreCacheRepository.java
+++ b/src/main/java/com/kurierfree/server/domain/matching/dao/MatchingScoreCacheRepository.java
@@ -1,0 +1,10 @@
+package com.kurierfree.server.domain.matching.dao;
+
+import com.kurierfree.server.domain.matching.domain.MatchingScoreCache;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
+
+public interface MatchingScoreCacheRepository extends JpaRepository<MatchingScoreCache, Long> {
+    List<MatchingScoreCache> findByDisabledStudentIdOrderByScoreDesc(Long disabledStudentId);
+    void deleteBySupporterId(Long supporterId); // 매칭 확정된 서포터즈 제거 시 사용
+}

--- a/src/main/java/com/kurierfree/server/domain/matching/dao/MatchingScoreCacheRepository.java
+++ b/src/main/java/com/kurierfree/server/domain/matching/dao/MatchingScoreCacheRepository.java
@@ -7,4 +7,6 @@ import java.util.List;
 public interface MatchingScoreCacheRepository extends JpaRepository<MatchingScoreCache, Long> {
     List<MatchingScoreCache> findByDisabledStudentIdOrderByScoreDesc(Long disabledStudentId);
     void deleteBySupporterId(Long supporterId); // 매칭 확정된 서포터즈 제거 시 사용
+
+    void deleteBySupporterIdAndDisabledStudentId(Long supporterId, Long disabledStudentId);
 }

--- a/src/main/java/com/kurierfree/server/domain/matching/domain/Matching.java
+++ b/src/main/java/com/kurierfree/server/domain/matching/domain/Matching.java
@@ -1,5 +1,6 @@
 package com.kurierfree.server.domain.matching.domain;
 
+import com.kurierfree.server.domain.matching.dto.response.MatchingResponse;
 import com.kurierfree.server.domain.semester.domain.Semester;
 import com.kurierfree.server.domain.user.domain.DisabledStudent;
 import com.kurierfree.server.domain.user.domain.Supporter;
@@ -31,9 +32,17 @@ public class Matching {
     private DisabledStudent disabledStudent;
 
     @Builder
-    public Matching(Semester semester, Supporter supporter, DisabledStudent disabledStudent) {
+    private Matching(Semester semester, Supporter supporter, DisabledStudent disabledStudent) {
         this.semester = semester;
         this.supporter = supporter;
         this.disabledStudent = disabledStudent;
+    }
+
+    public Matching of(Semester semester, Supporter supporter, DisabledStudent disabledStudent) {
+        return Matching.builder()
+                .semester(semester)
+                .supporter(supporter)
+                .disabledStudent(disabledStudent)
+                .build();
     }
 }

--- a/src/main/java/com/kurierfree/server/domain/matching/domain/Matching.java
+++ b/src/main/java/com/kurierfree/server/domain/matching/domain/Matching.java
@@ -1,6 +1,5 @@
 package com.kurierfree.server.domain.matching.domain;
 
-import com.kurierfree.server.domain.matching.dto.response.MatchingResponse;
 import com.kurierfree.server.domain.semester.domain.Semester;
 import com.kurierfree.server.domain.user.domain.DisabledStudent;
 import com.kurierfree.server.domain.user.domain.Supporter;
@@ -38,7 +37,7 @@ public class Matching {
         this.disabledStudent = disabledStudent;
     }
 
-    public Matching of(Semester semester, Supporter supporter, DisabledStudent disabledStudent) {
+    public static Matching of(Semester semester, Supporter supporter, DisabledStudent disabledStudent) {
         return Matching.builder()
                 .semester(semester)
                 .supporter(supporter)

--- a/src/main/java/com/kurierfree/server/domain/matching/domain/Matching.java
+++ b/src/main/java/com/kurierfree/server/domain/matching/domain/Matching.java
@@ -1,0 +1,39 @@
+package com.kurierfree.server.domain.matching.domain;
+
+import com.kurierfree.server.domain.semester.domain.Semester;
+import com.kurierfree.server.domain.user.domain.DisabledStudent;
+import com.kurierfree.server.domain.user.domain.Supporter;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Table(name = "matching")
+public class Matching {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(nullable = false)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "semester_id", nullable = false)
+    private Semester semester;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "supporter_id", nullable = false)
+    private Supporter supporter;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "disabled_student_id", nullable = false)
+    private DisabledStudent disabledStudent;
+
+    @Builder
+    public Matching(Semester semester, Supporter supporter, DisabledStudent disabledStudent) {
+        this.semester = semester;
+        this.supporter = supporter;
+        this.disabledStudent = disabledStudent;
+    }
+}

--- a/src/main/java/com/kurierfree/server/domain/matching/domain/MatchingScoreCache.java
+++ b/src/main/java/com/kurierfree/server/domain/matching/domain/MatchingScoreCache.java
@@ -27,22 +27,30 @@ public class MatchingScoreCache {
 
     private boolean departmentMatch;
 
+    private boolean isPreferredSupporter;
+
+    private int timeTableMatchScore;
+
     @Builder
-    private MatchingScoreCache(Long disabledStudentId, Long supporterId, int score, boolean genderMatch, boolean departmentMatch) {
+    private MatchingScoreCache(Long disabledStudentId, Long supporterId, int score, boolean genderMatch, boolean departmentMatch, boolean isPreferredSupporter, int timeTableMatchScore) {
         this.disabledStudentId = disabledStudentId;
         this.supporterId = supporterId;
         this.score = score;
         this.genderMatch = genderMatch;
         this.departmentMatch = departmentMatch;
+        this.isPreferredSupporter = isPreferredSupporter;
+        this.timeTableMatchScore = timeTableMatchScore;
     }
 
-    public static MatchingScoreCache of(Long disabledStudentId, Long supporterId, int score, boolean genderMatch, boolean departmentMatch) {
+    public static MatchingScoreCache of(Long disabledStudentId, Long supporterId, int score, boolean genderMatch, boolean departmentMatch, boolean isPreferredSupporter, int timeTableMatchScore) {
         return MatchingScoreCache.builder()
                 .disabledStudentId(disabledStudentId)
                 .supporterId(supporterId)
                 .score(score)
                 .genderMatch(genderMatch)
                 .departmentMatch(departmentMatch)
+                .isPreferredSupporter(isPreferredSupporter)
+                .timeTableMatchScore(timeTableMatchScore)
                 .build();
     }
 }

--- a/src/main/java/com/kurierfree/server/domain/matching/domain/MatchingScoreCache.java
+++ b/src/main/java/com/kurierfree/server/domain/matching/domain/MatchingScoreCache.java
@@ -1,6 +1,5 @@
 package com.kurierfree.server.domain.matching.domain;
 
-
 import jakarta.persistence.*;
 import lombok.*;
 

--- a/src/main/java/com/kurierfree/server/domain/matching/domain/MatchingScoreCache.java
+++ b/src/main/java/com/kurierfree/server/domain/matching/domain/MatchingScoreCache.java
@@ -1,0 +1,48 @@
+package com.kurierfree.server.domain.matching.domain;
+
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "matching_score_cache", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"disabledStudentId", "supporterId"})
+})
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+public class MatchingScoreCache {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long disabledStudentId;
+
+    private Long supporterId;
+
+    private int score;
+
+    private boolean genderMatch;
+
+    private boolean departmentMatch;
+
+    @Builder
+    private MatchingScoreCache(Long disabledStudentId, Long supporterId, int score, boolean genderMatch, boolean departmentMatch) {
+        this.disabledStudentId = disabledStudentId;
+        this.supporterId = supporterId;
+        this.score = score;
+        this.genderMatch = genderMatch;
+        this.departmentMatch = departmentMatch;
+    }
+
+    public static MatchingScoreCache of(Long disabledStudentId, Long supporterId, int score, boolean genderMatch, boolean departmentMatch) {
+        return MatchingScoreCache.builder()
+                .disabledStudentId(disabledStudentId)
+                .supporterId(supporterId)
+                .score(score)
+                .genderMatch(genderMatch)
+                .departmentMatch(departmentMatch)
+                .build();
+    }
+}

--- a/src/main/java/com/kurierfree/server/domain/matching/domain/MatchingScoreCache.java
+++ b/src/main/java/com/kurierfree/server/domain/matching/domain/MatchingScoreCache.java
@@ -30,6 +30,8 @@ public class MatchingScoreCache {
 
     private int timeTableMatchScore;
 
+    private boolean promotionStatus = false;
+
     @Builder
     private MatchingScoreCache(Long disabledStudentId, Long supporterId, int score, boolean genderMatch, boolean departmentMatch, boolean isPreferredSupporter, int timeTableMatchScore) {
         this.disabledStudentId = disabledStudentId;
@@ -51,5 +53,13 @@ public class MatchingScoreCache {
                 .isPreferredSupporter(isPreferredSupporter)
                 .timeTableMatchScore(timeTableMatchScore)
                 .build();
+    }
+
+    public void promoteToTop1() {
+        this.promotionStatus = true;
+    }
+
+    public void cancelPromotion() {
+        this.promotionStatus = false;
     }
 }

--- a/src/main/java/com/kurierfree/server/domain/matching/dto/request/MatchingRequest.java
+++ b/src/main/java/com/kurierfree/server/domain/matching/dto/request/MatchingRequest.java
@@ -8,6 +8,6 @@ import lombok.Getter;
 @Builder
 @AllArgsConstructor
 public class MatchingRequest {
-    private Long SupporterId;
+    private Long supporterId;
     private Long disabledStudentId;
 }

--- a/src/main/java/com/kurierfree/server/domain/matching/dto/request/MatchingRequest.java
+++ b/src/main/java/com/kurierfree/server/domain/matching/dto/request/MatchingRequest.java
@@ -1,0 +1,13 @@
+package com.kurierfree.server.domain.matching.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class MatchingRequest {
+    private Long SupporterId;
+    private Long disabledStudentId;
+}

--- a/src/main/java/com/kurierfree/server/domain/matching/dto/response/MatchingResponse.java
+++ b/src/main/java/com/kurierfree/server/domain/matching/dto/response/MatchingResponse.java
@@ -1,0 +1,14 @@
+package com.kurierfree.server.domain.matching.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class MatchingResponse {
+    private List<MatchingSupporters> matchingSupporters;
+}

--- a/src/main/java/com/kurierfree/server/domain/matching/dto/response/MatchingResponse.java
+++ b/src/main/java/com/kurierfree/server/domain/matching/dto/response/MatchingResponse.java
@@ -10,5 +10,5 @@ import java.util.List;
 @AllArgsConstructor
 @Builder
 public class MatchingResponse {
-    private List<MatchingSupporters> matchingSupporters;
+    private List<MatchingSupportersResponse> matchingSupporterResponses;
 }

--- a/src/main/java/com/kurierfree/server/domain/matching/dto/response/MatchingSupporters.java
+++ b/src/main/java/com/kurierfree/server/domain/matching/dto/response/MatchingSupporters.java
@@ -1,0 +1,18 @@
+package com.kurierfree.server.domain.matching.dto.response;
+
+import com.kurierfree.server.domain.user.domain.enums.Gender;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class MatchingSupporters {
+    private int rank;
+    private int studentId;
+    private String name;
+    private String department;
+    private Gender gender;
+    private String grade;
+}

--- a/src/main/java/com/kurierfree/server/domain/matching/dto/response/MatchingSupporters.java
+++ b/src/main/java/com/kurierfree/server/domain/matching/dto/response/MatchingSupporters.java
@@ -10,7 +10,7 @@ import lombok.Getter;
 @Builder
 public class MatchingSupporters {
     private int rank;
-    private int studentId;
+    private Long supporterId;
     private String name;
     private String department;
     private Gender gender;

--- a/src/main/java/com/kurierfree/server/domain/matching/dto/response/MatchingSupportersResponse.java
+++ b/src/main/java/com/kurierfree/server/domain/matching/dto/response/MatchingSupportersResponse.java
@@ -8,7 +8,7 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 @Builder
-public class MatchingSupporters {
+public class MatchingSupportersResponse {
     private int rank;
     private Long supporterId;
     private String name;

--- a/src/main/java/com/kurierfree/server/domain/semester/domain/Semester.java
+++ b/src/main/java/com/kurierfree/server/domain/semester/domain/Semester.java
@@ -20,6 +20,7 @@ public class Semester {
     @Column(nullable = false)
     private int year;
 
+    @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private SemesterTime semesterTime;
 

--- a/src/main/java/com/kurierfree/server/domain/timeTable/api/TimeTableApi.java
+++ b/src/main/java/com/kurierfree/server/domain/timeTable/api/TimeTableApi.java
@@ -8,7 +8,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/admin")
+@RequestMapping("/api")
 public class TimeTableApi {
     private final TimeTableService timeTableService;
 
@@ -16,11 +16,24 @@ public class TimeTableApi {
         this.timeTableService = timeTableService;
     }
 
-    @GetMapping("/timetable")
+    @GetMapping("/admin/users/{userId}/timetables")
     @Operation(summary = "시간표 가져오기")
-    public ResponseEntity<TimeTableResponse> getTimeTable(@RequestHeader("Authorization") String token) {
+    public ResponseEntity<TimeTableResponse> getTimeTableWithUserId(@PathVariable Long userId) {
         try{
-            TimeTableResponse timeTable = timeTableService.getTimeTable(token);
+            TimeTableResponse timeTable = timeTableService.getTimeTableWithUserId(userId);
+            return ResponseEntity.ok(timeTable);
+        } catch (EntityNotFoundException e){
+            return ResponseEntity.notFound().build();
+        } catch (IllegalStateException e){
+            return ResponseEntity.internalServerError().build();
+        }
+    }
+
+    @GetMapping("/timetables")
+    @Operation(summary = "시간표 가져오기")
+    public ResponseEntity<TimeTableResponse> getTimeTableWithToken(@RequestHeader("Authorization") String token) {
+        try{
+            TimeTableResponse timeTable = timeTableService.getTimeTableWithToken(token);
             return ResponseEntity.ok(timeTable);
         } catch (EntityNotFoundException e){
             return ResponseEntity.notFound().build();

--- a/src/main/java/com/kurierfree/server/domain/timeTable/application/TimeTableService.java
+++ b/src/main/java/com/kurierfree/server/domain/timeTable/application/TimeTableService.java
@@ -1,5 +1,6 @@
 package com.kurierfree.server.domain.timeTable.application;
 
+import com.kurierfree.server.domain.auth.enhancer.JwtAuthenticationFilter;
 import com.kurierfree.server.domain.auth.infra.JwtProvider;
 import com.kurierfree.server.domain.lesson.dao.LessonRepository;
 import com.kurierfree.server.domain.lesson.dto.response.LessonResponse;
@@ -28,10 +29,11 @@ public class TimeTableService {
     }
 
     @Transactional
-    public TimeTableResponse getTimeTable(String token) {
-        String jwtToken = token.substring(7);
-        Long userId = jwtProvider.getUserIdFromToken(jwtToken);
+    public TimeTableResponse getTimeTableWithUserId(Long userId) {
+        return getTimeTableResponse(userId);
+    }
 
+    private TimeTableResponse getTimeTableResponse(Long userId) {
         TimeTable timeTable= timeTableRepository.findByUserIdAndSemesterId(
                 userId, semesterService.getCurrentSemester().getId()
         );
@@ -48,6 +50,14 @@ public class TimeTableService {
         return TimeTableResponse.builder()
                 .lessons(lessonResponseList)
                 .build();
+    }
+
+    @Transactional
+    public TimeTableResponse getTimeTableWithToken(String token) {
+        String jwtToken = token.substring(7);
+        Long userId = jwtProvider.getUserIdFromToken(jwtToken);
+
+        return getTimeTableResponse(userId);
     }
 
 }

--- a/src/main/java/com/kurierfree/server/domain/timeTable/dao/TimeTableRepository.java
+++ b/src/main/java/com/kurierfree/server/domain/timeTable/dao/TimeTableRepository.java
@@ -1,8 +1,14 @@
 package com.kurierfree.server.domain.timeTable.dao;
 
 import com.kurierfree.server.domain.timeTable.domain.TimeTable;
+import com.kurierfree.server.domain.timeTable.domain.TimeTableLesson;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface TimeTableRepository extends JpaRepository<TimeTable, Long> {
-    TimeTable findByUserIdAndSemesterId(Long userId, Long semesterId);
+    @Query("SELECT l FROM TimeTable t JOIN t.lessons l WHERE t.user.id = :userId and t.semester.id = :semesterId")
+    List<TimeTableLesson> findLessonsByUserIdAndSemesterId(@Param("userId") Long userId, @Param("semesterId") Long semesterId);
 }

--- a/src/main/java/com/kurierfree/server/domain/timeTable/domain/TimeTable.java
+++ b/src/main/java/com/kurierfree/server/domain/timeTable/domain/TimeTable.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "time_table")
+@Table(name = "time_table", uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "semester_id"}))
 public class TimeTable {
 
     @Id

--- a/src/main/java/com/kurierfree/server/domain/timeTable/domain/TimeTable.java
+++ b/src/main/java/com/kurierfree/server/domain/timeTable/domain/TimeTable.java
@@ -8,6 +8,9 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -26,6 +29,9 @@ public class TimeTable {
     @JoinColumn(name = "semester_id", nullable = false)
     private Semester semester;
 
+    @OneToMany(mappedBy = "timeTable", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<TimeTableLesson> lessons = new ArrayList<>();
+
     @Builder
     private TimeTable( User user, Semester semester) {
         this.user = user;
@@ -38,4 +44,10 @@ public class TimeTable {
                 .semester(semester)
                 .build();
     }
+
+    public void addLesson(TimeTableLesson lesson) {
+        lessons.add(lesson);
+        lesson.setTimeTable(this);
+    }
+
 }

--- a/src/main/java/com/kurierfree/server/domain/timeTable/domain/TimeTableLesson.java
+++ b/src/main/java/com/kurierfree/server/domain/timeTable/domain/TimeTableLesson.java
@@ -2,16 +2,12 @@ package com.kurierfree.server.domain.timeTable.domain;
 
 import com.kurierfree.server.domain.lesson.domain.Lesson;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "time_table_lesson")
-
 public class TimeTableLesson {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -25,5 +21,18 @@ public class TimeTableLesson {
     @ManyToOne
     @JoinColumn(name = "lesson_id", nullable = false)
     private Lesson lesson;
+
+    @Builder
+    private TimeTableLesson(TimeTable timeTable, Lesson lesson) {
+        this.timeTable = timeTable;
+        this.lesson = lesson;
+    }
+
+    public static TimeTableLesson of(TimeTable timeTable, Lesson lesson) {
+        return TimeTableLesson.builder()
+                .timeTable(timeTable)
+                .lesson(lesson)
+                .build();
+    }
 
 }

--- a/src/main/java/com/kurierfree/server/domain/timeTable/domain/TimeTableLesson.java
+++ b/src/main/java/com/kurierfree/server/domain/timeTable/domain/TimeTableLesson.java
@@ -1,0 +1,29 @@
+package com.kurierfree.server.domain.timeTable.domain;
+
+import com.kurierfree.server.domain.lesson.domain.Lesson;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "time_table_lesson")
+
+public class TimeTableLesson {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Setter
+    @ManyToOne
+    @JoinColumn(name = "timetable_id", nullable = false)
+    private TimeTable timeTable;
+
+    @ManyToOne
+    @JoinColumn(name = "lesson_id", nullable = false)
+    private Lesson lesson;
+
+}

--- a/src/main/java/com/kurierfree/server/domain/user/application/UserService.java
+++ b/src/main/java/com/kurierfree/server/domain/user/application/UserService.java
@@ -4,11 +4,11 @@ import com.kurierfree.server.domain.auth.constant.JwtGrantType;
 import com.kurierfree.server.domain.auth.domain.JwtToken;
 import com.kurierfree.server.domain.auth.infra.JwtGenerator;
 import com.kurierfree.server.domain.auth.infra.JwtProvider;
-import com.kurierfree.server.domain.semester.application.SemesterService;
 import com.kurierfree.server.domain.user.dao.DisabledStudentRepository;
 import com.kurierfree.server.domain.user.dao.SupporterRepository;
 import com.kurierfree.server.domain.user.dao.UserRepository;
 import com.kurierfree.server.domain.user.domain.DisabledStudent;
+import com.kurierfree.server.domain.user.domain.enums.Gender;
 import com.kurierfree.server.domain.user.domain.enums.Role;
 import com.kurierfree.server.domain.user.domain.Supporter;
 import com.kurierfree.server.domain.user.domain.User;
@@ -17,6 +17,7 @@ import com.kurierfree.server.domain.user.dto.request.UserRegisterRequest;
 import com.kurierfree.server.domain.user.dto.response.UserLoginResponse;
 import com.kurierfree.server.domain.user.dto.response.UserRegisterResponse;
 import com.kurierfree.server.domain.user.dto.response.UserResponse;
+import jakarta.annotation.PostConstruct;
 import jakarta.persistence.EntityNotFoundException;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -27,7 +28,6 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserService {
     private final SupporterRepository supporterRepository;
     private final DisabledStudentRepository disabledStudentRepository;
-    private final SemesterService semesterService;
     private final UserRepository userRepository;
 
     private final PasswordEncoder passwordEncoder;
@@ -36,14 +36,12 @@ public class UserService {
 
     public UserService(SupporterRepository supporterRepository,
                        DisabledStudentRepository disabledStudentRepository,
-                       SemesterService semesterService,
                        UserRepository userRepository,
                        PasswordEncoder passwordEncoder,
                        JwtGenerator jwtGenerator,
                        JwtProvider jwtProvider) {
         this.supporterRepository = supporterRepository;
         this.disabledStudentRepository = disabledStudentRepository;
-        this.semesterService = semesterService;
         this.userRepository = userRepository;
 
         this.passwordEncoder = passwordEncoder;
@@ -75,8 +73,7 @@ public class UserService {
                 userRegisterRequest.getGender(),
                 userRegisterRequest.getGrade(),
                 passwordEncoder.encode(userRegisterRequest.getPassword()),
-                userRegisterRequest.getRole(),
-                semesterService.getCurrentSemester()
+                userRegisterRequest.getRole()
         );
         Supporter savedSupporter = supporterRepository.save(supporter);
         return savedSupporter.getId();
@@ -91,11 +88,19 @@ public class UserService {
                 userRegisterRequest.getGrade(),
                 passwordEncoder.encode(userRegisterRequest.getPassword()),
                 userRegisterRequest.getRole(),
-                semesterService.getCurrentSemester(),
                 userRegisterRequest.getDisabilityType()
         );
         DisabledStudent savedDisabledStudent = disabledStudentRepository.save(disabledStudent);
         return savedDisabledStudent.getId();
+    }
+
+    // admin 계정: id:0, password: admin
+    @PostConstruct
+    public void adminSave() {
+        if (userRepository.findByStudentId(0).isEmpty()) {
+            User admin = new User(0, "admin", "admin", Gender.FEMALE, "admin", passwordEncoder.encode("admin"), Role.ADMIN);
+            userRepository.save(admin);
+        }
     }
 
     @Transactional
@@ -103,11 +108,18 @@ public class UserService {
         User user = userRepository.findByStudentId(userLoginRequest.getStudentId())
                 .orElseThrow(() -> new EntityNotFoundException("해당 아이디를 가진 사용자가 존재하지 않습니다."));
 
-        JwtToken jwtToken = jwtGenerator.generateToken(user.getId(), JwtGrantType.GRANT_TYPE_USER.getValue());
-
         if (!passwordEncoder.matches(userLoginRequest.getPassword(), user.getPassword())){
             throw new BadCredentialsException("비밀번호가 일치하지 않습니다.");
         }
+
+        JwtToken jwtToken;
+        if (userLoginRequest.getStudentId() == 0){
+            jwtToken = jwtGenerator.generateToken(user.getId(), JwtGrantType.GRANT_TYPE_ADMIN.getValue());
+        }
+        else{
+            jwtToken = jwtGenerator.generateToken(user.getId(), JwtGrantType.GRANT_TYPE_USER.getValue());
+        }
+
         UserResponse userResponse = UserResponse.builder()
                 .userId(user.getId())
                 .role(user.getRole())

--- a/src/main/java/com/kurierfree/server/domain/user/dao/DisabledStudentRepository.java
+++ b/src/main/java/com/kurierfree/server/domain/user/dao/DisabledStudentRepository.java
@@ -16,4 +16,7 @@ public interface DisabledStudentRepository extends JpaRepository<DisabledStudent
     FROM DisabledStudent ds
 """)
     List<DisabledStudentResponse> findAllForAdmin();
+
+    @Query("SELECT d.id FROM DisabledStudent d")
+    List<Long> findAllIds(); // 모든 장애학생 ID만 추출
 }

--- a/src/main/java/com/kurierfree/server/domain/user/dao/SupporterRepository.java
+++ b/src/main/java/com/kurierfree/server/domain/user/dao/SupporterRepository.java
@@ -48,4 +48,6 @@ public interface SupporterRepository extends JpaRepository<Supporter, Long> {
 
     List<Supporter> findByStatus(Status status);
 
+    @Query("SELECT s.id FROM Supporter s")
+    List<Long> findAllIds(); // 모든 장애학생 ID만 추출
 }

--- a/src/main/java/com/kurierfree/server/domain/user/domain/DisabledStudent.java
+++ b/src/main/java/com/kurierfree/server/domain/user/domain/DisabledStudent.java
@@ -37,6 +37,6 @@ public class DisabledStudent extends User{
     }
 
     public boolean isPreferredSupporter(Long supporterId) {
-        return this.preferredSupporter != null && this.preferredSupporter.getId().equals(supporterId);
+        return this.preferredSupporter != null && this.preferredSupporter.getId() == supporterId;
     }
 }

--- a/src/main/java/com/kurierfree/server/domain/user/domain/DisabledStudent.java
+++ b/src/main/java/com/kurierfree/server/domain/user/domain/DisabledStudent.java
@@ -35,4 +35,8 @@ public class DisabledStudent extends User{
     public void updateStatusMatched() {
         this.status = Status.MATCHED;
     }
+
+    public boolean isPreferredSupporter(Long supporterId) {
+        return this.preferredSupporter != null && this.preferredSupporter.getId().equals(supporterId);
+    }
 }

--- a/src/main/java/com/kurierfree/server/domain/user/domain/DisabledStudent.java
+++ b/src/main/java/com/kurierfree/server/domain/user/domain/DisabledStudent.java
@@ -1,6 +1,5 @@
 package com.kurierfree.server.domain.user.domain;
 
-import com.kurierfree.server.domain.semester.domain.Semester;
 import com.kurierfree.server.domain.user.domain.enums.Status;
 import com.kurierfree.server.domain.user.domain.enums.DisabilityType;
 import com.kurierfree.server.domain.user.domain.enums.Gender;
@@ -28,8 +27,8 @@ public class DisabledStudent extends User{
     @JoinColumn(name = "preferred_supporter_id")
     private Supporter preferredSupporter;
 
-    public DisabledStudent(int studentId, String name, String department, Gender gender, String grade, String password, Role role, Semester semester, DisabilityType disabilityType) {
-        super(studentId, name, department, gender, grade, password, role, semester);
+    public DisabledStudent(int studentId, String name, String department, Gender gender, String grade, String password, Role role, DisabilityType disabilityType) {
+        super(studentId, name, department, gender, grade, password, role);
         this.disabilityType = disabilityType;
     }
 }

--- a/src/main/java/com/kurierfree/server/domain/user/domain/DisabledStudent.java
+++ b/src/main/java/com/kurierfree/server/domain/user/domain/DisabledStudent.java
@@ -31,4 +31,8 @@ public class DisabledStudent extends User{
         super(studentId, name, department, gender, grade, password, role);
         this.disabilityType = disabilityType;
     }
+
+    public void updateStatusMatched() {
+        this.status = Status.MATCHED;
+    }
 }

--- a/src/main/java/com/kurierfree/server/domain/user/domain/DisabledStudent.java
+++ b/src/main/java/com/kurierfree/server/domain/user/domain/DisabledStudent.java
@@ -14,11 +14,13 @@ import lombok.NoArgsConstructor;
 @Table(name = "disabled_student")
 public class DisabledStudent extends User{
 
+    @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private DisabilityType disabilityType;
 
     private String specialRequirements;
 
+    @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private Status status = Status.MATCHING;
 

--- a/src/main/java/com/kurierfree/server/domain/user/domain/Supporter.java
+++ b/src/main/java/com/kurierfree/server/domain/user/domain/Supporter.java
@@ -1,6 +1,5 @@
 package com.kurierfree.server.domain.user.domain;
 
-import com.kurierfree.server.domain.semester.domain.Semester;
 import com.kurierfree.server.domain.user.domain.enums.Status;
 import com.kurierfree.server.domain.user.domain.enums.Gender;
 import com.kurierfree.server.domain.user.domain.enums.Role;
@@ -21,8 +20,8 @@ public class Supporter extends User{
     @Column(nullable = false)
     private Status status = Status.PENDING;
 
-    public Supporter(int studentId, String name, String department, Gender gender, String grade, String password, Role role, Semester semester) {
-        super(studentId, name, department, gender, grade, password, role, semester);
+    public Supporter(int studentId, String name, String department, Gender gender, String grade, String password, Role role) {
+        super(studentId, name, department, gender, grade, password, role);
     }
 
     public void updateStatus(Status status) {

--- a/src/main/java/com/kurierfree/server/domain/user/domain/Supporter.java
+++ b/src/main/java/com/kurierfree/server/domain/user/domain/Supporter.java
@@ -17,6 +17,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "supporter")
 public class Supporter extends User{
 
+    @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private Status status = Status.PENDING;
 

--- a/src/main/java/com/kurierfree/server/domain/user/domain/Supporter.java
+++ b/src/main/java/com/kurierfree/server/domain/user/domain/Supporter.java
@@ -20,6 +20,9 @@ public class Supporter extends User{
     @Column(nullable = false)
     private Status status = Status.PENDING;
 
+    @Column(nullable = false)
+    private int matchingCount = 0;
+
     public Supporter(int studentId, String name, String department, Gender gender, String grade, String password, Role role) {
         super(studentId, name, department, gender, grade, password, role);
     }
@@ -30,5 +33,14 @@ public class Supporter extends User{
 
     public void changeToRejected() {
         this.status = Status.REJECTED;
+    }
+
+    public void updateStatusMatched() {
+        this.status = Status.MATCHED;
+    }
+
+    public boolean updateAndValidSupporterMatchCount() {
+        this.matchingCount = matchingCount + 1;
+        return matchingCount < 2;
     }
 }

--- a/src/main/java/com/kurierfree/server/domain/user/domain/Supporter.java
+++ b/src/main/java/com/kurierfree/server/domain/user/domain/Supporter.java
@@ -4,15 +4,13 @@ import com.kurierfree.server.domain.user.domain.enums.Status;
 import com.kurierfree.server.domain.user.domain.enums.Gender;
 import com.kurierfree.server.domain.user.domain.enums.Role;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
+@Getter
 @Table(name = "supporter")
 public class Supporter extends User{
 
@@ -21,7 +19,7 @@ public class Supporter extends User{
     private Status status = Status.PENDING;
 
     @Column(nullable = false)
-    private int matchingCount = 0;
+    private int supporterMatchCount = 0;
 
     public Supporter(int studentId, String name, String department, Gender gender, String grade, String password, Role role) {
         super(studentId, name, department, gender, grade, password, role);
@@ -40,7 +38,7 @@ public class Supporter extends User{
     }
 
     public boolean updateAndValidSupporterMatchCount() {
-        this.matchingCount = matchingCount + 1;
-        return matchingCount < 2;
+        this.supporterMatchCount = supporterMatchCount + 1;
+        return supporterMatchCount < 2;
     }
 }

--- a/src/main/java/com/kurierfree/server/domain/user/domain/User.java
+++ b/src/main/java/com/kurierfree/server/domain/user/domain/User.java
@@ -1,6 +1,5 @@
 package com.kurierfree.server.domain.user.domain;
 
-import com.kurierfree.server.domain.semester.domain.Semester;
 import com.kurierfree.server.domain.user.domain.enums.Gender;
 import com.kurierfree.server.domain.user.domain.enums.Role;
 import jakarta.persistence.*;
@@ -42,11 +41,7 @@ public class User {
     @Column(nullable = false)
     private Role role;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "semester_id", nullable = false)
-    private Semester semester;
-
-    public User(int studentId, String name, String department, Gender gender, String grade, String password, Role role, Semester semester) {
+    public User(int studentId, String name, String department, Gender gender, String grade, String password, Role role) {
         this.studentId = studentId;
         this.name = name;
         this.department = department;
@@ -54,6 +49,5 @@ public class User {
         this.gender = gender;
         this.password = password;
         this.role = role;
-        this.semester = semester;
     }
 }

--- a/src/main/java/com/kurierfree/server/domain/user/domain/User.java
+++ b/src/main/java/com/kurierfree/server/domain/user/domain/User.java
@@ -28,6 +28,7 @@ public class User {
     @Column(nullable = false)
     private String department;
 
+    @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private Gender gender;
 
@@ -37,6 +38,7 @@ public class User {
     @Column(nullable = false)
     private String password;
 
+    @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private Role role;
 

--- a/src/main/java/com/kurierfree/server/global/config/SecurityConfig.java
+++ b/src/main/java/com/kurierfree/server/global/config/SecurityConfig.java
@@ -16,6 +16,11 @@ import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 @Configuration
@@ -34,6 +39,7 @@ public class SecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
 
         return httpSecurity
+                .cors(c -> c.configurationSource(corsConfigurationSource()))
                 .csrf(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)
@@ -54,6 +60,20 @@ public class SecurityConfig {
                 )
                 .build();
     }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowedOriginPatterns(List.of("*")); // or use List.of("http://localhost:3000") if you want to restrict
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"));
+        config.setAllowedHeaders(List.of("*"));
+        config.setAllowCredentials(true); // Authorization 헤더 포함 허용
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return source;
+    }
+
     @Bean
     public PasswordEncoder passwordEncoder() {
         return PasswordEncoderFactories.createDelegatingPasswordEncoder();

--- a/src/main/java/com/kurierfree/server/global/config/SwaggerConfig.java
+++ b/src/main/java/com/kurierfree/server/global/config/SwaggerConfig.java
@@ -34,6 +34,11 @@ public class SwaggerConfig {
         SecurityRequirement securityRequirement = new SecurityRequirement()
                 .addList("Bearer Token");
 
+
+        Server prodServer = new Server();
+        prodServer.setUrl("http://13.125.243.173:8080");
+        prodServer.setDescription("AWS EC2 서버");
+
         Server localServer = new Server();
         localServer.setUrl("http://localhost:8080");
         localServer.setDescription("Local server for testing");
@@ -41,7 +46,7 @@ public class SwaggerConfig {
         return new OpenAPI()
                 .components(new Components().addSecuritySchemes("Bearer Token", apiKey))
                 .addSecurityItem(securityRequirement)
-                .servers(List.of(localServer));}
+                .servers(List.of(localServer, prodServer));}
     ;
 
 }

--- a/src/main/java/com/kurierfree/server/global/config/WebMvcConfig.java
+++ b/src/main/java/com/kurierfree/server/global/config/WebMvcConfig.java
@@ -1,12 +1,19 @@
 package com.kurierfree.server.global.config;
 
+import com.kurierfree.server.domain.auth.Interceptor.AuthInterceptor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
 public class WebMvcConfig implements WebMvcConfigurer {
     private final long MAX_AGE_SECS = 3600;
+    private AuthInterceptor authInterceptor;
+
+    public WebMvcConfig(AuthInterceptor authInterceptor) {
+        this.authInterceptor = authInterceptor;
+    }
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {
@@ -16,5 +23,10 @@ public class WebMvcConfig implements WebMvcConfigurer {
                 .allowedHeaders("*")
                 .allowCredentials(true)
                 .maxAge(MAX_AGE_SECS);
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(authInterceptor);
     }
 }


### PR DESCRIPTION
# 매칭 api (#7)

### ❗️ 매칭 api
**api/admin/matchings**

### ❗️장애학생 별 서포터즈 매칭 Top3 조회
**api/admin/disabled-students/{disabled-students_id}/matchings**
- 현재 서버 실행시 1회 매칭 테이블 생성됨 
-> 추후 선발 기간 구현 후, 선발 기간이 시작에 맞춰 테이블 첫 생성으로 수정시킬 계획입니다.
- 장애학생 수업시간이 서포터즈 활동 가능시간인가 점수 로직 미완입니다.
-> 추후 서포터즈 지원서 수현 후 수정하겠습니다.

### ❗️/api/admin 으로 들어오는 요청의 토큰 ADMIN인지 검증
- 토큰 따로 받아서 검증 로직 생략해도됨

### ❗️TimeTable, Lesson 관련 도메인 설계 변경
- TimeTableLesson (시간표-수업 매핑)중간 테이블을 추가하여 TimeTable 과 Lesson의 다대다 관계를 피함
- LessonSchedule 클래스를 추가해서 여러 요일 및 시간에 시작하는 수업 저장 가능합니다.
- TimeTable : User = N : 1
- TimeTable : Semester = N : 1
- TimeTable : TimeTableLesson = 1:N
- Lesson: TimeTableLesson = 1:N
- Lesson: LessonSchedule = 1:N
----
# TO REVIEWER
- 서포터즈 활동 가능시간과 장애학생 수업시간 매치 점수 로직 미구현
- 저거 TimeTable 관련 테이블들 설계 잘한건지 몰겟슘 ㅜㅜ