### PR TITLE
Feat: 지원/선발 기간 api

### DIFF
--- a/src/main/java/com/kurierfree/server/domain/semester/api/SemesterApi.java
+++ b/src/main/java/com/kurierfree/server/domain/semester/api/SemesterApi.java
@@ -1,9 +1,8 @@
 package com.kurierfree.server.domain.semester.api;
 
-import com.kurierfree.server.domain.list.application.ListService;
-import com.kurierfree.server.domain.list.dto.response.DisabledStudentResponse;
 import com.kurierfree.server.domain.semester.application.SemesterService;
 import com.kurierfree.server.domain.semester.dto.request.RecruitmentPeriodRequest;
+import com.kurierfree.server.domain.semester.dto.response.RecruitmentPeriodResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
@@ -39,6 +38,20 @@ public class SemesterApi {
         try {
             semesterService.setSelectionPeriod(semesterId, recruitmentPeriodRequest);
             return ResponseEntity.ok("선발 기간이 설정되었습니다.");
+        } catch (EntityNotFoundException e) {
+            return ResponseEntity.notFound().build();
+        } catch (AccessDeniedException e) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        } catch (IllegalStateException e) {
+            return ResponseEntity.internalServerError().build();
+        }
+    }
+    @Operation(summary = "지원 기간, 선발 기간 조회")
+    @GetMapping("/recruitment-period")
+    public ResponseEntity<RecruitmentPeriodResponse> getRecruitmentPeriod(@PathVariable Long semesterId) {
+        try {
+            RecruitmentPeriodResponse recruitmentPeriodResponse = semesterService.getRecruitmentPeriod(semesterId);
+            return ResponseEntity.ok(recruitmentPeriodResponse);
         } catch (EntityNotFoundException e) {
             return ResponseEntity.notFound().build();
         } catch (AccessDeniedException e) {

--- a/src/main/java/com/kurierfree/server/domain/semester/api/SemesterApi.java
+++ b/src/main/java/com/kurierfree/server/domain/semester/api/SemesterApi.java
@@ -46,7 +46,8 @@ public class SemesterApi {
             return ResponseEntity.internalServerError().build();
         }
     }
-    @Operation(summary = "지원 기간, 선발 기간 조회")
+    @Operation(summary = "지원 기간, 선발 기간 조회",
+            description = "isSelectionEndAfterNow = true 면, 마감날이 현재 날짜와 동일하거나 이후라는 뜻")
     @GetMapping("/recruitment-period")
     public ResponseEntity<RecruitmentPeriodResponse> getRecruitmentPeriod(@PathVariable Long semesterId) {
         try {

--- a/src/main/java/com/kurierfree/server/domain/semester/api/SemesterApi.java
+++ b/src/main/java/com/kurierfree/server/domain/semester/api/SemesterApi.java
@@ -1,0 +1,50 @@
+package com.kurierfree.server.domain.semester.api;
+
+import com.kurierfree.server.domain.list.application.ListService;
+import com.kurierfree.server.domain.list.dto.response.DisabledStudentResponse;
+import com.kurierfree.server.domain.semester.application.SemesterService;
+import com.kurierfree.server.domain.semester.dto.request.RecruitmentPeriodRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/admin/semester/{semesterId}")
+@RequiredArgsConstructor
+public class SemesterApi {
+    private final SemesterService semesterService;
+
+    @Operation(summary = "지원 기간 설정")
+    @PostMapping("/application-period")
+    public ResponseEntity<?> setApplicationPeriod(@PathVariable Long semesterId, @RequestBody RecruitmentPeriodRequest recruitmentPeriodRequest) {
+        try {
+            semesterService.setApplicationPeriod(semesterId, recruitmentPeriodRequest);
+            return ResponseEntity.ok("지원 기간이 설정되었습니다.");
+        } catch (EntityNotFoundException e) {
+            return ResponseEntity.notFound().build();
+        } catch (AccessDeniedException e) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        } catch (IllegalStateException e) {
+            return ResponseEntity.internalServerError().build();
+        }
+    }
+
+    @Operation(summary = "선발 기간 설정")
+    @PostMapping("/selection-period")
+    public ResponseEntity<?> setSelectionPeriod(@PathVariable Long semesterId, @RequestBody RecruitmentPeriodRequest recruitmentPeriodRequest) {
+        try {
+            semesterService.setSelectionPeriod(semesterId, recruitmentPeriodRequest);
+            return ResponseEntity.ok("선발 기간이 설정되었습니다.");
+        } catch (EntityNotFoundException e) {
+            return ResponseEntity.notFound().build();
+        } catch (AccessDeniedException e) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        } catch (IllegalStateException e) {
+            return ResponseEntity.internalServerError().build();
+        }
+    }
+}

--- a/src/main/java/com/kurierfree/server/domain/semester/application/SemesterService.java
+++ b/src/main/java/com/kurierfree/server/domain/semester/application/SemesterService.java
@@ -3,9 +3,12 @@ package com.kurierfree.server.domain.semester.application;
 import com.kurierfree.server.domain.semester.dao.SemesterRepository;
 import com.kurierfree.server.domain.semester.domain.Semester;
 import com.kurierfree.server.domain.semester.dto.request.RecruitmentPeriodRequest;
+import com.kurierfree.server.domain.semester.dto.response.RecruitmentPeriodResponse;
 import jakarta.persistence.EntityNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
 
 @Service
 public class SemesterService {
@@ -48,5 +51,13 @@ public class SemesterService {
                 recruitmentPeriodRequest.getStartDate(),
                 recruitmentPeriodRequest.getEndDate()
         );
+    }
+
+    @Transactional
+    public RecruitmentPeriodResponse getRecruitmentPeriod(Long semesterId) {
+        Semester semester = semesterRepository.findById(semesterId)
+                .orElseThrow(() -> new EntityNotFoundException("Semester not found with id: " + semesterId));
+
+        return RecruitmentPeriodResponse.from(semester, LocalDate.now());
     }
 }

--- a/src/main/java/com/kurierfree/server/domain/semester/application/SemesterService.java
+++ b/src/main/java/com/kurierfree/server/domain/semester/application/SemesterService.java
@@ -2,6 +2,8 @@ package com.kurierfree.server.domain.semester.application;
 
 import com.kurierfree.server.domain.semester.dao.SemesterRepository;
 import com.kurierfree.server.domain.semester.domain.Semester;
+import com.kurierfree.server.domain.semester.dto.request.RecruitmentPeriodRequest;
+import jakarta.persistence.EntityNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,5 +26,27 @@ public class SemesterService {
         Semester newSemester = Semester.createCurrentSemester();
         Semester findSemester = semesterRepository.findByYearAndSemesterTime(newSemester.getYear(), newSemester.getSemesterTime());
         return (findSemester != null) ? findSemester : createAndSaveCurrentSemester();
+    }
+
+    @Transactional
+    public void setApplicationPeriod(Long semesterId, RecruitmentPeriodRequest recruitmentPeriodRequest) {
+        Semester semester = semesterRepository.findById(semesterId)
+                .orElseThrow(() -> new EntityNotFoundException("Semester not found with id: " + semesterId));
+
+        semester.updateApplicationPeriod(
+                recruitmentPeriodRequest.getStartDate(),
+                recruitmentPeriodRequest.getEndDate()
+        );
+    }
+
+    @Transactional
+    public void setSelectionPeriod(Long semesterId, RecruitmentPeriodRequest recruitmentPeriodRequest) {
+        Semester semester = semesterRepository.findById(semesterId)
+                .orElseThrow(() -> new EntityNotFoundException("Semester not found with id: " + semesterId));
+
+        semester.updateSelectionPeriod(
+                recruitmentPeriodRequest.getStartDate(),
+                recruitmentPeriodRequest.getEndDate()
+        );
     }
 }

--- a/src/main/java/com/kurierfree/server/domain/semester/domain/Semester.java
+++ b/src/main/java/com/kurierfree/server/domain/semester/domain/Semester.java
@@ -24,6 +24,18 @@ public class Semester {
     @Column(nullable = false)
     private SemesterTime semesterTime;
 
+    @Column
+    private LocalDate applicationStartDate;
+
+    @Column
+    private LocalDate applicationEndDate;
+
+    @Column
+    private LocalDate selectionStartDate;
+
+    @Column
+    private LocalDate selectionEndDate;
+
     public Semester(int currentYear, SemesterTime currentSemesterTime) {
         this.year = currentYear;
         this.semesterTime = currentSemesterTime;
@@ -41,5 +53,15 @@ public class Semester {
             currentSemesterTime = SemesterTime.FALL;
         }
         return new Semester(currentYear, currentSemesterTime);
+    }
+
+    public void updateApplicationPeriod(LocalDate start, LocalDate end) {
+        this.applicationStartDate = start;
+        this.applicationEndDate = end;
+    }
+
+    public void updateSelectionPeriod(LocalDate start, LocalDate end) {
+        this.selectionStartDate = start;
+        this.selectionEndDate = end;
     }
 }

--- a/src/main/java/com/kurierfree/server/domain/semester/dto/request/RecruitmentPeriodRequest.java
+++ b/src/main/java/com/kurierfree/server/domain/semester/dto/request/RecruitmentPeriodRequest.java
@@ -1,0 +1,15 @@
+package com.kurierfree.server.domain.semester.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class RecruitmentPeriodRequest {
+    private LocalDate startDate;
+    private LocalDate endDate;
+}

--- a/src/main/java/com/kurierfree/server/domain/semester/dto/response/RecruitmentPeriodResponse.java
+++ b/src/main/java/com/kurierfree/server/domain/semester/dto/response/RecruitmentPeriodResponse.java
@@ -1,0 +1,37 @@
+package com.kurierfree.server.domain.semester.dto.response;
+
+import com.kurierfree.server.domain.semester.domain.Semester;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class RecruitmentPeriodResponse {
+    private LocalDate applicationStart;
+    private LocalDate applicationEnd;
+    private boolean isApplicationBeforeNow;
+
+    private LocalDate selectionStart;
+    private LocalDate selectionEnd;
+    private boolean isSelectionBeforeNow;
+
+    public static RecruitmentPeriodResponse from(Semester semester, LocalDate now) {
+        return RecruitmentPeriodResponse.builder()
+                .applicationStart(semester.getApplicationStartDate())
+                .applicationEnd(semester.getApplicationEndDate())
+                .isApplicationBeforeNow(isBefore(now, semester.getApplicationEndDate()))
+
+                .selectionStart(semester.getSelectionStartDate())
+                .selectionEnd(semester.getSelectionEndDate())
+                .isSelectionBeforeNow(isBefore(now, semester.getSelectionEndDate()))
+                .build();
+    }
+
+    private static boolean isBefore(LocalDate now, LocalDate end) {
+        return end != null && !now.isAfter(end);
+    }
+}

--- a/src/main/java/com/kurierfree/server/domain/semester/dto/response/RecruitmentPeriodResponse.java
+++ b/src/main/java/com/kurierfree/server/domain/semester/dto/response/RecruitmentPeriodResponse.java
@@ -13,25 +13,25 @@ import java.time.LocalDate;
 public class RecruitmentPeriodResponse {
     private LocalDate applicationStart;
     private LocalDate applicationEnd;
-    private boolean isApplicationBeforeNow;
+    private boolean isApplicationEndAfterNow;
 
     private LocalDate selectionStart;
     private LocalDate selectionEnd;
-    private boolean isSelectionBeforeNow;
+    private boolean isSelectionEndAfterNow;
 
     public static RecruitmentPeriodResponse from(Semester semester, LocalDate now) {
         return RecruitmentPeriodResponse.builder()
                 .applicationStart(semester.getApplicationStartDate())
                 .applicationEnd(semester.getApplicationEndDate())
-                .isApplicationBeforeNow(isBefore(now, semester.getApplicationEndDate()))
+                .isApplicationEndAfterNow(isBefore(now, semester.getApplicationEndDate()))
 
                 .selectionStart(semester.getSelectionStartDate())
                 .selectionEnd(semester.getSelectionEndDate())
-                .isSelectionBeforeNow(isBefore(now, semester.getSelectionEndDate()))
+                .isSelectionEndAfterNow(isBefore(now, semester.getSelectionEndDate()))
                 .build();
     }
 
     private static boolean isBefore(LocalDate now, LocalDate end) {
-        return end != null && !now.isAfter(end);
+        return end != null && !now.isAfter(end); // 설정날까지 true
     }
 }


### PR DESCRIPTION
# 지원/선발 기간 api
- closed #14 

### ❗️ 지원 기간설정 api
**api/admin/semester/{semesterId}/application-period**

### ❗️선발 기간설정 api
**api/admin/semester/{semesterId}/selection-period**

### ❗️지원/선발 기간 조회 api
**api/admin/semester/{semesterId}/recruitment-period**
<img width="370" alt="스크린샷 2025-05-15 01 06 24" src="https://github.com/user-attachments/assets/cb327e11-e81d-4434-a847-333b86ed1cfd" />

----
# TO REVIEWER
- semester entity 에 column 으로 지원기간/선발기간 추가