### PR TITLE
[Feat] 매칭 알고리즘 - 지원서 매칭반영

### DIFF
--- a/src/main/java/com/kurierfree/server/domain/application/application/ApplicationService.java
+++ b/src/main/java/com/kurierfree/server/domain/application/application/ApplicationService.java
@@ -5,6 +5,7 @@ import com.kurierfree.server.domain.application.domain.ActivityPreference;
 import com.kurierfree.server.domain.application.domain.Application;
 import com.kurierfree.server.domain.application.dto.request.ApplicationRequest;
 import com.kurierfree.server.domain.application.dto.response.ApplicationResponse;
+import com.kurierfree.server.domain.user.domain.Supporter;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -53,5 +54,13 @@ public class ApplicationService {
         Application save = applicationRepository.save(application);
 
         return ApplicationResponse.from(save);
+    }
+
+    public List<ActivityPreference> getActivityPreference(Supporter supporter) {
+        Application application = applicationRepository.findByStudentId(supporter.getStudentId());
+        if (application == null || application.getActivityPreference().isEmpty()) {
+            return List.of();
+        }
+        return application.getActivityPreference();
     }
 }

--- a/src/main/java/com/kurierfree/server/domain/application/application/ApplicationService.java
+++ b/src/main/java/com/kurierfree/server/domain/application/application/ApplicationService.java
@@ -41,7 +41,9 @@ public class ApplicationService {
                     .map(dto -> ActivityPreference.of(
                             dto.getPriority(),
                             dto.getPreferredActivity(),
-                            dto.getAvailableTime()
+                            dto.getClassDay(),
+                            dto.getStartTime(),
+                            dto.getEndTime()
                     ))
                     .toList();
 

--- a/src/main/java/com/kurierfree/server/domain/application/dao/ApplicationRepository.java
+++ b/src/main/java/com/kurierfree/server/domain/application/dao/ApplicationRepository.java
@@ -3,5 +3,8 @@ package com.kurierfree.server.domain.application.dao;
 import com.kurierfree.server.domain.application.domain.Application;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ApplicationRepository extends JpaRepository<Application, Long> {
+    Application findByStudentId(int studentId);
 }

--- a/src/main/java/com/kurierfree/server/domain/application/domain/ActivityPreference.java
+++ b/src/main/java/com/kurierfree/server/domain/application/domain/ActivityPreference.java
@@ -1,6 +1,8 @@
 package com.kurierfree.server.domain.application.domain;
 
-import jakarta.persistence.Embeddable;
+import com.kurierfree.server.domain.lesson.domain.ClassDay;
+import com.kurierfree.server.domain.lesson.domain.ClassTime;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,5 +14,22 @@ import lombok.NoArgsConstructor;
 public class ActivityPreference {
     private int priority;
     private String preferredActivity;
-    private String availableTime;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ClassDay classDay;
+
+    @Embedded
+    @AttributeOverrides({
+            @AttributeOverride(name = "hour", column = @Column(name = "start_hour", nullable = false)),
+            @AttributeOverride(name = "minute", column = @Column(name = "start_minute", nullable = false))
+    })
+    private ClassTime startTime;
+
+    @Embedded
+    @AttributeOverrides({
+            @AttributeOverride(name = "hour", column = @Column(name = "end_hour", nullable = false)),
+            @AttributeOverride(name = "minute", column = @Column(name = "end_minute", nullable = false))
+    })
+    private ClassTime endTime;
 }

--- a/src/main/java/com/kurierfree/server/domain/application/dto/request/ApplicationRequest.java
+++ b/src/main/java/com/kurierfree/server/domain/application/dto/request/ApplicationRequest.java
@@ -1,7 +1,8 @@
 package com.kurierfree.server.domain.application.dto.request;
 
-import com.kurierfree.server.domain.application.domain.ActivityPreference;
 import com.kurierfree.server.domain.application.domain.enums.ActivityType;
+import com.kurierfree.server.domain.lesson.domain.ClassDay;
+import com.kurierfree.server.domain.lesson.domain.ClassTime;
 import com.kurierfree.server.domain.user.domain.enums.Gender;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -33,6 +34,9 @@ public class ApplicationRequest {
         private int priority;
         private String preferredActivity;
         private String availableTime;
+        private ClassDay classDay;
+        private ClassTime startTime;
+        private ClassTime endTime;
     }
 
 }

--- a/src/main/java/com/kurierfree/server/domain/lesson/domain/ClassTime.java
+++ b/src/main/java/com/kurierfree/server/domain/lesson/domain/ClassTime.java
@@ -3,6 +3,8 @@ package com.kurierfree.server.domain.lesson.domain;
 import jakarta.persistence.Embeddable;
 import lombok.Getter;
 
+import java.time.LocalTime;
+
 @Embeddable
 @Getter
 public class ClassTime {
@@ -35,6 +37,10 @@ public class ClassTime {
     @Override
     public String toString() {
         return String.format("%02d:%02d", hour, minute);
+    }
+
+    public LocalTime toLocalTime() {
+        return LocalTime.of(hour, minute);
     }
 
 }

--- a/src/main/java/com/kurierfree/server/domain/matching/application/MatchingService.java
+++ b/src/main/java/com/kurierfree/server/domain/matching/application/MatchingService.java
@@ -1,5 +1,6 @@
 package com.kurierfree.server.domain.matching.application;
 
+import com.kurierfree.server.domain.application.dao.ApplicationRepository;
 import com.kurierfree.server.domain.matching.dao.MatchingRepository;
 import com.kurierfree.server.domain.matching.dao.MatchingScoreCacheRepository;
 import com.kurierfree.server.domain.matching.domain.Matching;
@@ -15,6 +16,7 @@ import com.kurierfree.server.domain.user.domain.DisabledStudent;
 import com.kurierfree.server.domain.user.domain.Supporter;
 import jakarta.annotation.PostConstruct;
 import jakarta.persistence.EntityNotFoundException;
+import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,6 +24,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 @Service
+@AllArgsConstructor
 public class MatchingService {
     private final MatchingRepository matchingRepository;
     private final SupporterRepository supporterRepository;
@@ -29,22 +32,7 @@ public class MatchingService {
     private final SemesterService semesterService;
     private final MatchingScoreCacheRepository matchingScoreCacheRepository;
     private final TimeTableService timeTableService;
-
-    public MatchingService(
-            MatchingRepository matchingRepository,
-            SupporterRepository supporterRepository,
-            DisabledStudentRepository disabledStudentRepository,
-            SemesterService semesterService,
-            MatchingScoreCacheRepository matchingScoreCacheRepository,
-            TimeTableService timeTableService
-    ) {
-        this.matchingRepository = matchingRepository;
-        this.supporterRepository = supporterRepository;
-        this.disabledStudentRepository = disabledStudentRepository;
-        this.semesterService = semesterService;
-        this.matchingScoreCacheRepository = matchingScoreCacheRepository;
-        this.timeTableService = timeTableService;
-    }
+    private final ApplicationRepository applicationRepository;
 
     @Transactional
     public void createMatching(MatchingRequest matchingRequest) {
@@ -177,6 +165,9 @@ public class MatchingService {
         boolean isPreferredSupporter = disabledStudent.isPreferredSupporter(supporterId);
 
         // Todo: 장애학생 수업시간 = 서포터즈 활동 가능시간인가
+
+
+
         // 동일 과목 수강 여부
         int timeTableMatchScore = timeTableService.compareTimeTableScore(disabledStudentsId, supporterId);
 

--- a/src/main/java/com/kurierfree/server/domain/matching/application/MatchingService.java
+++ b/src/main/java/com/kurierfree/server/domain/matching/application/MatchingService.java
@@ -1,6 +1,9 @@
 package com.kurierfree.server.domain.matching.application;
 
+import com.kurierfree.server.domain.application.application.ApplicationService;
 import com.kurierfree.server.domain.application.dao.ApplicationRepository;
+import com.kurierfree.server.domain.application.domain.ActivityPreference;
+import com.kurierfree.server.domain.lesson.domain.LessonSchedule;
 import com.kurierfree.server.domain.matching.dao.MatchingRepository;
 import com.kurierfree.server.domain.matching.dao.MatchingScoreCacheRepository;
 import com.kurierfree.server.domain.matching.domain.Matching;
@@ -20,6 +23,7 @@ import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalTime;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -32,7 +36,7 @@ public class MatchingService {
     private final SemesterService semesterService;
     private final MatchingScoreCacheRepository matchingScoreCacheRepository;
     private final TimeTableService timeTableService;
-    private final ApplicationRepository applicationRepository;
+    private final ApplicationService applicationService;
 
     @Transactional
     public void createMatching(MatchingRequest matchingRequest) {
@@ -164,9 +168,8 @@ public class MatchingService {
         // 사전 지정이라면 1순위로 만들기
         boolean isPreferredSupporter = disabledStudent.isPreferredSupporter(supporterId);
 
-        // Todo: 장애학생 수업시간 = 서포터즈 활동 가능시간인가
-
-
+        // 장애학생 수업시간 = 서포터즈 활동 가능시간인가
+        int activityPreferenceScore = getActivityPreferenceScore(disabledStudentsId, supporter);
 
         // 동일 과목 수강 여부
         int timeTableMatchScore = timeTableService.compareTimeTableScore(disabledStudentsId, supporterId);
@@ -181,6 +184,7 @@ public class MatchingService {
         if (isPreferredSupporter) score += 100;
         if (genderMatch) score += 3;
         if (departmentMatch) score += 1;
+        score += activityPreferenceScore;
         score += timeTableMatchScore;
 
         MatchingScoreCache matchingScoreCache = MatchingScoreCache.of(
@@ -194,6 +198,43 @@ public class MatchingService {
                 );
 
         matchingScoreCacheRepository.save(matchingScoreCache);
+    }
+
+    private int getActivityPreferenceScore(Long disabledStudentsId, Supporter supporter) {
+        int score = 0;
+        List<LessonSchedule> lessonSchedules = timeTableService.getTimeTable(disabledStudentsId);
+        List<ActivityPreference> preferences = applicationService.getActivityPreference(supporter);
+        for (ActivityPreference preference : preferences) {
+            for (LessonSchedule schedule : lessonSchedules) {
+                if (isOverlapping(preference, schedule)) {
+                    score += getScoreByPriority(preference.getPriority());
+                }
+            }
+        }
+        return score;
+    }
+
+    private boolean isOverlapping(ActivityPreference pref, LessonSchedule schedule) {
+        if (!pref.getClassDay().equals(schedule.getClassDay())) return false;
+
+        // ClassTime → LocalTime 변환
+        LocalTime prefStart = pref.getStartTime().toLocalTime();
+        LocalTime prefEnd = pref.getEndTime().toLocalTime();
+        LocalTime classStart = schedule.getStartTime().toLocalTime();
+        LocalTime classEnd = schedule.getEndTime().toLocalTime();
+
+        // 시간이 겹치는지 확인
+        return !(prefEnd.isBefore(classStart) || prefStart.isAfter(classEnd));
+    }
+
+
+    private int getScoreByPriority(int priority) {
+        // 예시: priority 1등은 3점, 2등은 2점, 그 외는 1점
+        return switch (priority) {
+            case 1 -> 30;
+            case 2 -> 20;
+            default -> 10;
+        };
     }
 
     // 매칭 score 저장: 선발기간 시작시기에 맞춰 1회만 실행

--- a/src/main/java/com/kurierfree/server/domain/timeTable/application/TimeTableService.java
+++ b/src/main/java/com/kurierfree/server/domain/timeTable/application/TimeTableService.java
@@ -3,6 +3,7 @@ package com.kurierfree.server.domain.timeTable.application;
 import com.kurierfree.server.domain.auth.infra.JwtProvider;
 import com.kurierfree.server.domain.lesson.dao.LessonRepository;
 import com.kurierfree.server.domain.lesson.domain.Lesson;
+import com.kurierfree.server.domain.lesson.domain.LessonSchedule;
 import com.kurierfree.server.domain.lesson.dto.response.LessonResponse;
 import com.kurierfree.server.domain.lesson.dto.response.LessonScheduleResponse;
 import com.kurierfree.server.domain.semester.application.SemesterService;
@@ -67,6 +68,19 @@ public class TimeTableService {
         return TimeTableResponse.builder()
                 .lessons(lessonResponseList)
                 .build();
+    }
+    @Transactional
+    public List<LessonSchedule> getTimeTable(Long userId) {
+        List<TimeTableLesson> timeTableLessons= timeTableRepository.findLessonsByUserIdAndSemesterId(
+                userId, semesterService.getCurrentSemester().getId()
+        );
+        if (timeTableLessons.isEmpty()) {
+            return List.of();
+        }
+
+        return timeTableLessons.stream()
+                .flatMap(tl -> tl.getLesson().getLessonSchedules().stream())
+                .toList();
     }
 
     public int compareTimeTableScore(Long disabledStudentId, Long supporterId) {


### PR DESCRIPTION
# [Feat] 매칭 알고리즘 - 지원서 매칭반영
- closed #7 

## 🌀 장애학생 별 매칭 3순위 조회 api
**api/admin/disabled-students/{disabledStudentsId}/matchings**

- response
```
{
  "matchingSupporterResponses": [
    {
      "rank": 1,
      "supporterId": 12,
      "name": "s333",
      "department": "string",
      "gender": "MALE",
      "grade": "string"
    },
    {
      "rank": 2,
      "supporterId": 10,
      "name": "s111",
      "department": "string",
      "gender": "FEMALE",
      "grade": "string"
    },
    {
      "rank": 3,
      "supporterId": 8,
      "name": "s111",
      "department": "string",
      "gender": "MALE",
      "grade": "string"
    }
  ]
}
```

----
## 🌀TO REVIEWER
- api 응답에 변화는 없습니다! 알고리즘만 지원서 반영해서 수정했어용
- 지원서 활동 가능 시간을 수업 시간 형식과 통일하여 ClassDay, ClassTime type 으로 변경하였습니다!!